### PR TITLE
Fix unexisting child processes in poolboy_sup

### DIFF
--- a/src/poolboy.erl
+++ b/src/poolboy.erl
@@ -272,6 +272,7 @@ handle_info({'EXIT', Pid, Reason}, StateName, State) ->
            waiting = Waiting,
            monitors = Monitors,
            max_overflow = MaxOverflow} = State,
+    supervisor:terminate_child(Sup, Pid),
     case ets:lookup(Monitors, Pid) of
         [{Pid, Ref}] ->
             true = erlang:demonitor(Ref),


### PR DESCRIPTION
Hi,

I've noticed that, when one of the poolboy's worker process exits it is restarted but still exists on child list of poolboy_sup (the same received by get_all_workers).
I've added an explicit call to supervisor:terminate_child/2 to handle that issue.

Thanks
