### PR TITLE
App version should be 0.9.1

### DIFF
--- a/src/poolboy.app.src
+++ b/src/poolboy.app.src
@@ -1,6 +1,6 @@
 {application, poolboy, [
     {description, "A hunky Erlang worker pool factory"},
-    {vsn, "0.8.1"},
+    {vsn, "0.9.1"},
     {applications, [kernel, stdlib]},
     {registered, [poolboy]}
 ]}.


### PR DESCRIPTION
App version should be 0.9.1. Else, rebar fails:

{version_mismatch,{"/Users/dmitrii.dimandt/Projects/solo/como/deps/poolboy/src/poolboy.app.src",
                   {expected,"0.9.1"},
                   {has,"0.8.1"}}}.
