### PR TITLE
Add back-off ability.

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ code_change(_OldVsn, State, _Extra) ->
 - `worker_module`: the module that represents the workers
 - `size`: maximum pool size
 - `max_overflow`: maximum number of workers created if pool is empty
+- `backoff`: handle spawn timeouts in case if worker is unable to be started
 
 ## Authors
 

--- a/test/poolboy_test_worker.erl
+++ b/test/poolboy_test_worker.erl
@@ -6,11 +6,25 @@
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
          code_change/3]).
 
-start_link(_Args) ->
-    gen_server:start_link(?MODULE, [], []).
+start_link(Args) ->
+    gen_server:start_link(?MODULE, Args, []).
 
 init([]) ->
-    {ok, undefined}.
+    {ok, undefined};
+init([{locker, Locker} | Args]) ->
+    %% this is used by backoff tests to emulate database(or other resource)
+    %% slownest
+    Locker ! {may_i_proceed, self()},
+    receive
+        ok ->
+            init(Args);
+        Else ->
+            {error, Else}
+    after 200 ->
+        {error, timeout}
+    end;
+init([_A | Args]) ->
+    init(Args).
 
 handle_call(die, _From, State) ->
     {stop, {error, died}, dead, State};


### PR DESCRIPTION
### Ratio

If worker can not not be spawned for some reason(database is offline) poolboy will die. This pull request adds new option to spawn worker:

```
{backoff, {Mod, Fun, Args}}
```

which is intended to increase time-outs between worker restarts if something going wrong.
### Main idea

instead of worker spawn, we spawn a wrapper, which sleeps for some time, awakes, spawn worker and delegate this worker to poolboy.

If backoff option is not specified then worker will be spawned as usual (i.e. synchronous).
### Tests

if you try to run test with backoff enabled option, some of them will fail (like those, who kill worker and immediately try to count them with  `get_avail_workers` as spawn still in progress). Perhaps some of such calls should be re-designed. Thus with disabled backoff all tests are fine.
