### PR TITLE
Fix dialyzer

### DIFF
--- a/.dialyzer-ignore-warnings
+++ b/.dialyzer-ignore-warnings
@@ -1,0 +1,1 @@
+# Need at least one line here


### PR DESCRIPTION
Use a non-empty `.dialyzer-ignore-warnings`, otherwise fgrep will
have completed before dialyzer pipes stdout to it
