### PR TITLE
Compatibility with 17.0-rc2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,3 @@
-{erl_opts, [debug_info, warnings_as_errors]}.
+{erl_opts, [debug_info]}.
 {eunit_opts, [verbose]}.
 {cover_enabled, true}.


### PR DESCRIPTION
Type queue() warns on 17.0, queue:queue() warns on R16, so disable
warnings_as_errors for now.
