### PR TITLE
Added 'nowarn_deprecated_type' to rebar configuration.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,6 @@
-{erl_opts, [debug_info]}.
+{erl_opts, [
+    debug_info,
+    nowarn_deprecated_type
+]}.
 {eunit_opts, [verbose]}.
 {cover_enabled, true}.


### PR DESCRIPTION
When compiling `poolboy` with Erlang/ OTP 17, the compiler rises some warnings/errors saying the following:

``` shell
~/poolboy/src/poolboy.erl:16: type queue/0 is deprecated and will be removed in OTP 18.0; use use queue:queue/0 or preferably queue:queue/2
~/poolboy/src/poolboy.erl:17: type queue/0 is deprecated and will be removed in OTP 18.0; use use queue:queue/0 or preferably queue:queue/2
```

I couldn't compile `boss_db` for R17 because `poolboy` and `riakc` had these errors.

As I see it, there are three fixes for these compiler errors:
1. Changing `queue()` for `queue:queue()` in lines 16 and 17 of poolboy.erl. This would break `poolboy` for older Erlang versions. I guess is the only solution when R18 arrives though.
2. Saying `poolboy` is not compatible with R17 in the README.md.
3. Add `nowarn_deprecated_type` compiler flag to the rebar configuration. This would make `poolboy` compatible with R17 and previous Erlang versions as well (not compatible for R18, though). _IMHO I believe this is the best solution for now. Therefore this is the solution I propose with this pull request._

This fix does not break any of the tests as expected.
