### PR TITLE
Include version in package.exs

### DIFF
--- a/package.exs
+++ b/package.exs
@@ -11,7 +11,7 @@ defmodule Poolboy.Mixfile do
   end
 
   defp package do
-    [files: ~w(src rebar.config README.md LICENSE UNLICENSE),
+    [files: ~w(src rebar.config README.md LICENSE UNLICENSE VERSION),
      contributors: ["Devin Torres", "Andrew Thompson", "Kurt Williams"],
      licenses: ["Unlicense", "Apache 2.0"],
      links: [{"GitHub", "https://github.com/devinus/poolboy"}]]


### PR DESCRIPTION
Otherwise, the project does not compile successfully.

After this change is applied, I would advise for a new
package to be published on hex.pm.
