### PR TITLE
FIX clean shutdown in supervision tree

### DIFF
--- a/src/poolboy.erl
+++ b/src/poolboy.erl
@@ -234,6 +234,8 @@ handle_info({'EXIT', Pid, _Reason}, State) ->
 handle_info(_Info, State) ->
     {noreply, State}.
 
+terminate(shutdown, #state{workers=Workers}) ->
+    ok = lists:foreach(fun (W) -> unlink(W) end, Workers);
 terminate(_Reason, _State) ->
     ok.
 


### PR DESCRIPTION
This is a really minimal fix to solve error reports like this:

```
(my_node@pro13)1> application:stop(my_app).
ok
(my_node@pro13)2> 17:12:53.342 [error] Supervisor {<0.113.0>,poolboy_sup} had child my_child started with my_child:start_link([...]) at undefined exit with reason shutdown in context shutdown_error
17:12:53.346 [info] Application my_app exited with reason: stopped
```

This fixes this particular issue and nothing else, which is really well described in answer number 2 here: http://stackoverflow.com/questions/19354937/strange-error-message-when-stopping-app-using-lager-and-poolboy

The proper fix is having poolboy.erl not linking to the workers but monitoring them, as attempted in #37. 
