### PR TITLE
fix double list wrap for worker arguments

### DIFF
--- a/src/poolboy_sup.erl
+++ b/src/poolboy_sup.erl
@@ -10,5 +10,5 @@ start_link(Mod, Args) ->
 
 init({Mod, Args}) ->
     {ok, {{simple_one_for_one, 0, 1},
-          [{Mod, {Mod, start_link, [Args]},
+          [{Mod, {Mod, start_link, Args},
             temporary, 5000, worker, [Mod]}]}}.


### PR DESCRIPTION
put args for workers in pool init like ["127.0.0.1",8087] and worker get [["127.0.0.1",8087]]

<!---
@huboard:{"order":13.5,"milestone_order":54,"custom_state":""}
-->
