### PR TITLE
allow pids in typespecs

### DIFF
--- a/src/poolboy.erl
+++ b/src/poolboy.erl
@@ -18,7 +18,7 @@
 -endif.
 
 -type pool() ::
-    Name :: atom() |
+    Name :: (atom() | pid()) |
     {Name :: atom(), node()} |
     {local, Name :: atom()} |
     {global, GlobalName :: any()} |


### PR DESCRIPTION
Fixes dialyzer errors that occur when pure pids are used with poolboy operations (such as `transaction/2`)
