### PR TITLE
Fix setting monitors on calling processes

### DIFF
--- a/src/poolboy.erl
+++ b/src/poolboy.erl
@@ -279,8 +279,7 @@ handle_checkin(Pid, State) ->
            monitors = Monitors,
            overflow = Overflow} = State,
     case queue:out(Waiting) of
-        {{value, {{FromPid, _} = From, _}}, Left} ->
-            Ref = erlang:monitor(process, FromPid),
+        {{value, {From, Ref}}, Left} ->
             true = ets:insert(Monitors, {Pid, Ref}),
             gen_server:reply(From, Pid),
             State#state{waiting = Left};


### PR DESCRIPTION
When a process was in the waiting list, it was being monitored twice but only one monitor later got canceled.

In my system I have a lot of long living processes that are using poolboy.
Under heavy load, some of the processes got queued in #state.waiting with their pid and monitor reference. During checkin, another erlang:monitor was set, so after a couple of hours I started receiving long_schedule alarms. Using process_info I found out that the poolboy gen_server had ~12 million monitors.

The fix uses the monitor reference taken from the waiting list instead of creating a new one.
