### PR TITLE
Ability to specify keep alive time for excess workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ code_change(_OldVsn, State, _Extra) ->
 - `worker_module`: the module that represents the workers
 - `size`: maximum pool size
 - `max_overflow`: maximum number of workers created if pool is empty
+- `keep_alive_time`: maximum time in milliseconds that excess workers will wait
+  for new tasks before terminating (default 0)
 - `strategy`: `lifo` or `fifo`, determines whether checked in workers should be
   placed first or last in the line of available workers. Default is `lifo`.
 

--- a/src/poolboy.erl
+++ b/src/poolboy.erl
@@ -307,12 +307,10 @@ prepopulate(N, Sup, Workers) ->
     prepopulate(N-1, Sup, [new_worker(Sup) | Workers]).
 
 handle_checkin(Pid, State) ->
-    #state{supervisor = Sup,
-           waiting = Waiting,
+    #state{waiting = Waiting,
            monitors = Monitors,
            overflow = Overflow,
-           keep_alive_time = KeepAliveTime,
-           strategy = Strategy} = State,
+           keep_alive_time = KeepAliveTime} = State,
     case queue:out(Waiting) of
         {{value, {From, Ref}}, Left} ->
             true = ets:insert(Monitors, {Pid, Ref}),

--- a/test/poolboy_tests.erl
+++ b/test/poolboy_tests.erl
@@ -136,7 +136,7 @@ pool_keep_alive() ->
     % base workers
     {W1, W2} = {poolboy:checkout(Pid), poolboy:checkout(Pid)},
     % new workers
-    {W3, W4} = {poolboy:checkout(Pid), poolboy:checkout(Pid)},
+    {_W3, _W4} = {poolboy:checkout(Pid), poolboy:checkout(Pid)},
 
     ?assertMatch({_, 0, 2, 4}, pool_call(Pid, status)),
 
@@ -148,7 +148,7 @@ pool_keep_alive() ->
 
     timer:sleep(1000),
     % get back
-    W11 = poolboy:checkout(Pid),
+    _W11 = poolboy:checkout(Pid),
 
     timer:sleep(2000),
     ?assertEqual(3, length(pool_call(Pid, get_all_workers))),


### PR DESCRIPTION
In case when load is not uniformly distributed and have periodic peaks immediately termination of excess workers is not very good strategy because a little later again need to create new workers. Continually re-creation of new workers causes degradation of performance.