### PR TITLE
Export pool/0 type

### DIFF
--- a/src/poolboy.erl
+++ b/src/poolboy.erl
@@ -8,6 +8,7 @@
          start_link/1, start_link/2, stop/1, status/1]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
          code_change/3]).
+-export_type([pool/0]).
 
 -define(TIMEOUT, 5000).
 


### PR DESCRIPTION
This is to allow libraries that calls poolboy to specify their function typespecs.