### PR TITLE
Fix checkout timeout race condition

### DIFF
--- a/test/poolboy_tests.erl
+++ b/test/poolboy_tests.erl
@@ -69,6 +69,8 @@ pool_test_() ->
             {<<"Pool reuses waiting monitor when a worker exits">>,
                 fun reuses_waiting_monitor_on_worker_exit/0
             },
+            {<<"Recover from timeout without exit handling">>,
+                fun transaction_timeout_without_exit/0},
             {<<"Recover from transaction timeout">>,
                 fun transaction_timeout/0}
         ]
@@ -89,6 +91,22 @@ checkin_worker(Pid, Worker) ->
     %% worker. The only solution seems to be a nasty hardcoded sleep.
     poolboy:checkin(Pid, Worker),
     timer:sleep(500).
+
+
+transaction_timeout_without_exit() ->
+    {ok, Pid} = new_pool(1, 0),
+    ?assertEqual({ready,1,0,0}, pool_call(Pid, status)),
+    WorkerList = pool_call(Pid, get_all_workers),
+    ?assertMatch([_], WorkerList),
+    spawn(poolboy, transaction, [Pid,
+        fun(Worker) ->
+            ok = pool_call(Worker, work)
+        end,
+        0]),
+    timer:sleep(100),
+    ?assertEqual(WorkerList, pool_call(Pid, get_all_workers)),
+    ?assertEqual({ready,1,0,0}, pool_call(Pid, status)).
+
 
 transaction_timeout() ->
     {ok, Pid} = new_pool(1, 0),

--- a/test/poolboy_tests.erl
+++ b/test/poolboy_tests.erl
@@ -467,15 +467,16 @@ demonitors_previously_waiting_processes() ->
 
 demonitors_when_checkout_cancelled() ->
     {ok, Pool} = new_pool(1,0),
+    Self = self(),
     Pid = spawn(fun() ->
         poolboy:checkout(Pool),
-        poolboy:checkout(Pool),
+        _ = (catch poolboy:checkout(Pool, true, 1000)),
+        Self ! ok,
         receive ok -> ok end
     end),
     timer:sleep(500),
     ?assertEqual(2, length(get_monitors(Pool))),
-    gen_server:cast(Pool, {cancel_waiting, Pid}),
-    timer:sleep(500),
+    receive ok -> ok end,
     ?assertEqual(1, length(get_monitors(Pool))),
     Pid ! ok,
     ok = pool_call(Pool, stop).
@@ -516,7 +517,12 @@ reuses_waiting_monitor_on_worker_exit() ->
     end),
 
     Worker = receive {worker, Worker} -> Worker end,
+    Ref = monitor(process, Worker),
     exit(Worker, kill),
+    receive
+        {'DOWN', Ref, _, _, _} ->
+            ok
+    end,
 
     ?assertEqual(1, length(get_monitors(Pool))),
 
@@ -524,6 +530,8 @@ reuses_waiting_monitor_on_worker_exit() ->
     ok = pool_call(Pool, stop).
 
 get_monitors(Pid) ->
+    %% Synchronise with the Pid to ensure it has handled all expected work.
+    _ = sys:get_status(Pid),
     [{monitors, Monitors}] = erlang:process_info(Pid, [monitors]),
     Monitors.
 


### PR DESCRIPTION
Previously it was possible for the pool to checkout a worker to a client but the client to timeout before receiving the worker's pid. This would leave the worker checked out until the client process exited.