### PR TITLE
reproduce worker termination race condition

### DIFF
--- a/test/poolboy_test_worker.erl
+++ b/test/poolboy_test_worker.erl
@@ -17,6 +17,8 @@ handle_call(die, _From, State) ->
 handle_call(_Event, _From, State) ->
     {reply, ok, State}.
 
+handle_cast(die, State) ->
+    {stop, {error, died}, State};
 handle_cast(_Event, State) ->
     {noreply, State}.
 


### PR DESCRIPTION
There is a race condition between checking out of a worker from the pool and worker process's termination. In test case provided worker is terminated via gen_server:cast for more reliable reproducing, but it also occurs on gen_server:call.
Is it a know issue? Is there any recommendation of how to avoid it?