### PR TITLE
More generic argument passing when spawning workers

### DIFF
--- a/src/poolboy.erl
+++ b/src/poolboy.erl
@@ -94,7 +94,7 @@ child_spec(PoolId, PoolArgs, WorkerArgs) ->
 -spec start(PoolArgs :: proplists:proplist())
     -> start_ret().
 start(PoolArgs) ->
-    start(PoolArgs, PoolArgs).
+    start(PoolArgs, [PoolArgs]).
 
 -spec start(PoolArgs :: proplists:proplist(),
             WorkerArgs:: proplists:proplist())
@@ -106,7 +106,7 @@ start(PoolArgs, WorkerArgs) ->
     -> start_ret().
 start_link(PoolArgs)  ->
     %% for backwards compatability, pass the pool args as the worker args as well
-    start_link(PoolArgs, PoolArgs).
+    start_link(PoolArgs, [PoolArgs]).
 
 -spec start_link(PoolArgs :: proplists:proplist(),
                  WorkerArgs:: proplists:proplist())

--- a/src/poolboy_sup.erl
+++ b/src/poolboy_sup.erl
@@ -10,5 +10,5 @@ start_link(Mod, Args) ->
 
 init({Mod, Args}) ->
     {ok, {{simple_one_for_one, 0, 1},
-          [{Mod, {Mod, start_link, [Args]},
+          [{Mod, {Mod, start_link, Args},
             temporary, 5000, worker, [Mod]}]}}.


### PR DESCRIPTION
Hello!

Poolboy is a really great tool, and we use it a lot for several years. But currently it has some strange limitation: it allows worker servers' spawning function (`start_link` or smth.) to accept only single argument.

Of course this PR breaks backward compatibility, and it's main goal is to raise a discussion about this limitation. Are there any unobvious reasons for it? And are there any plans/ideas about removing it?
