### PR TITLE
workers with dynamic arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,11 @@ code_change(_OldVsn, State, _Extra) ->
 ## Options
 
 - `name`: the pool name
-- `worker_module`: the module that represents the workers
-- `size`: maximum pool size
+- `worker_module`: the module that represents the workers, if the workers are created
+  with dynamic arguments (each one of them) then you must pass a list and each element
+  of the list is a new worker. example: `{worker_module, {worker, [[1], [2]]}}`.
+- `size`: maximum pool size, if you use dynamical workers then the size is detected from 
+  list arguments length
 - `max_overflow`: maximum number of workers created if pool is empty
 - `strategy`: `lifo` or `fifo`, determines whether checked in workers should be
   placed first or last in the line of available workers. Default is `lifo`.

--- a/src/poolboy_sup.erl
+++ b/src/poolboy_sup.erl
@@ -8,7 +8,11 @@
 start_link(Mod, Args) ->
     supervisor:start_link(?MODULE, {Mod, Args}).
 
-init({Mod, Args}) ->
+init({_Mod, {dynamic, _Args}}) ->
+    % arguments are dynamic for each worker, then each worker must
+    % be created dynamically
+    {ok, { {one_for_one, 0, 1}, []} };
+init({Mod, Args})           ->
     {ok, {{simple_one_for_one, 0, 1},
           [{Mod, {Mod, start_link, [Args]},
             temporary, 5000, worker, [Mod]}]}}.

--- a/test/poolboy_test_worker_dyn.erl
+++ b/test/poolboy_test_worker_dyn.erl
@@ -1,0 +1,32 @@
+-module(poolboy_test_worker_dyn).
+-behaviour(gen_server).
+-behaviour(poolboy_worker).
+
+-export([start_link/1]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
+         code_change/3]).
+
+start_link(Args) ->
+    gen_server:start_link(?MODULE, [Args], []).
+
+init([[N]]) ->
+    {ok, N}.
+
+handle_call(die, _From, State) ->
+    {stop, {error, died}, dead, State};
+handle_call(get_info, _From, State) ->
+    {reply, {ok, State}, State};
+handle_call(_Event, _From, State) ->
+    {reply, ok, State}.
+
+handle_cast(_Event, State) ->
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.


### PR DESCRIPTION
Hello, 

We recently used `poolboy` to manage many workers (`gen_server`), but we check one problem, for example, each `gen_server` manage a socket connection in a port, so for example, each argument for each `gen_server` is the port where the socket will be opened, but we want manage the workers in a pool, to `checkout` and `checkin` the workers to establish a channel, and after when the channel is released, then `checkin` to the pool.

Then we decide modify some parts in the code of `poolboy` in order to make it works, we add tests for the new addition and modify the README file to show how it works.

I hope this can be helpful for the project and for other people having the same problem.
