### PR TITLE
Updated README.md to clarify {strategy...} options

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ code_change(_OldVsn, State, _Extra) ->
 - `size`: maximum pool size
 - `max_overflow`: maximum number of workers created if pool is empty
 - `strategy`: `lifo` or `fifo`, determines whether checked in workers should be
-  placed first or last in the line of available workers. Default is `lifo`.
+  placed first or last in the line of available workers. So, `lifo` operates like a traditional stack; `fifo` like a queue. Default is `lifo`.
 
 ## Authors
 


### PR DESCRIPTION
Clarified lifo and fifo modes as I found the current description quite confusing.

Used 
`{empty, Empty} ->
            Workers = case Strategy of
                lifo -> [Pid | State#state.workers];
                fifo -> State#state.workers ++ [Pid]
            end,`

to come to this conclusion.