### PR TITLE
Improved logic for checking overflow workers 

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -1,0 +1,25 @@
+name: Erlang CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+permissions:
+  contents: read
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    container:
+      image: erlang:22.0.7
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Compile
+      run: rebar3 compile
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+/rebar.lock
+/poolboy.iml
+/.idea
 .eunit
 .rebar
 _build

--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ code_change(_OldVsn, State, _Extra) ->
   placed first or last in the line of available workers. Default is `lifo`.
 - `overflow_ttl`: time in milliseconds you want to wait before removing overflow
   workers. Useful when it's expensive to start workers. Default is 0.
+- `overflow_check_period`: time in milliseconds for checking overflow workers to rip. 
+  Default is min(1 sec, overflow_ttl). Cheking job will not be started, if overflow_ttl is 0.
   
 ## Pool Status
 Returns : {Status, Workers, Overflow, InUse}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Poolboy - A hunky Erlang worker pool factory
 
-[![Build Status](https://api.travis-ci.org/devinus/poolboy.svg?branch=master)](https://travis-ci.org/devinus/poolboy)
+[![Build Status](https://api.travis-ci.org/comtihon/poolboy.svg?branch=master)](https://travis-ci.org/comtihon/poolboy)
 
-[![Support via Gratipay](https://cdn.rawgit.com/gratipay/gratipay-badge/2.3.0/dist/gratipay.png)](https://gratipay.com/devinus/)
 
 Poolboy is a **lightweight**, **generic** pooling library for Erlang with a
 focus on **simplicity**, **performance**, and **rock-solid** disaster recovery.
@@ -161,7 +160,14 @@ code_change(_OldVsn, State, _Extra) ->
 ## Pool Options
 
 - `name`: the pool name - optional
-- `worker_module`: the module that represents the workers - mandatory
+- `worker_module`: worker module. Can be either a `module` or `{module, function}`.
+Example:
+```
+start_pool(SizeArgs, WorkerArgs) ->
+  PoolArgs = [{worker_module, {mc_worker_api, connect}}] ++ SizeArgs,
+  supervisor:start_child(?MODULE, [PoolArgs, WorkerArgs]).
+```
+In case of just atom `start_link` will be called.
 - `size`: maximum pool size - optional
 - `max_overflow`: maximum number of workers created if pool is empty - optional
 - `strategy`: `lifo` or `fifo`, determines whether checked in workers should be
@@ -183,15 +189,3 @@ Returns : {Status, Workers, Overflow, InUse}
 - `Overflow`: Number of overflow workers started, should never exceed number 
               specified by MaxOverflow when starting pool
 - `InUse`: Number of workers currently busy/checked out
-
-## Authors
-
-- Devin Torres (devinus) <devin@devintorres.com>
-- Andrew Thompson (Vagabond) <andrew@hijacked.us>
-- Kurt Williams (onkel-dirtus) <kurt.r.williams@gmail.com>
-
-## License
-
-Poolboy is available in the public domain (see `UNLICENSE`).
-Poolboy is also optionally available under the ISC license (see `LICENSE`),
-meant especially for jurisdictions that do not recognize public domain works.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Poolboy is a **lightweight**, **generic** pooling library for Erlang with a
 focus on **simplicity**, **performance**, and **rock-solid** disaster recovery.
 
 ## Usage
-
+The most basic use case is to check out a worker, make a call and manually 
+return it to the pool when done
 ```erl-sh
 1> Worker = poolboy:checkout(PoolName).
 <0.9001.0>
@@ -17,7 +18,16 @@ ok
 3> poolboy:checkin(PoolName, Worker).
 ok
 ```
-
+Alternatively you can use a transaction which will return the worker to the 
+pool when the call is finished, the caller is gone, the call has exited or 
+the timeout set has been reached
+```erl-sh
+poolboy:transaction(
+    PoolName,
+    fun(Worker) -> gen_server:call(Worker, Request) end, 
+    TransactionTimeout
+)
+```
 ## Example
 
 This is an example application showcasing database connection pools using
@@ -149,14 +159,29 @@ code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 ```
 
-## Options
+## Pool Options
 
-- `name`: the pool name
-- `worker_module`: the module that represents the workers
-- `size`: maximum pool size
-- `max_overflow`: maximum number of workers created if pool is empty
+- `name`: the pool name - optional
+- `worker_module`: the module that represents the workers - mandatory
+- `size`: maximum pool size - optional
+- `max_overflow`: maximum number of workers created if pool is empty - optional
 - `strategy`: `lifo` or `fifo`, determines whether checked in workers should be
   placed first or last in the line of available workers. Default is `lifo`.
+- `overflow_ttl`: time in milliseconds you want to wait before removing overflow
+  workers. Useful when it's expensive to start workers. Default is 0.
+  
+## Pool Status
+Returns : {Status, Workers, Overflow, InUse}
+- `Status`: ready | full | overflow
+            The ready atom indicates there are workers that are not checked out 
+            ready. The full atom indicates all workers including overflow are 
+            checked out. The overflow atom is used to describe the condition 
+            when all permanent workers are in use but there is overflow capacity 
+            available.
+- `Workers`: Number of workers ready for use.
+- `Overflow`: Number of overflow workers started, should never exceed number 
+              specified by MaxOverflow when starting pool
+- `InUse`: Number of workers currently busy/checked out
 
 ## Authors
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Poolboy - A hunky Erlang worker pool factory
 
-[![Build Status](https://api.travis-ci.org/comtihon/poolboy.svg?branch=master)](https://travis-ci.org/comtihon/poolboy)
-
+[![Erlang CI](https://github.com/comtihon/poolboy/actions/workflows/erlang.yml/badge.svg)](https://github.com/comtihon/poolboy/actions/workflows/erlang.yml)
 
 Poolboy is a **lightweight**, **generic** pooling library for Erlang with a
 focus on **simplicity**, **performance**, and **rock-solid** disaster recovery.

--- a/src/poolboy.app.src
+++ b/src/poolboy.app.src
@@ -1,6 +1,6 @@
 {application, poolboy, [
     {description, "A hunky Erlang worker pool factory"},
-    {vsn, "1.6.0"},
+    {vsn, "1.6.1"},
     {applications, [kernel, stdlib]},
     {registered, [poolboy]},
 

--- a/src/poolboy.app.src
+++ b/src/poolboy.app.src
@@ -1,6 +1,6 @@
 {application, poolboy, [
     {description, "A hunky Erlang worker pool factory"},
-    {vsn, "1.5.1"},
+    {vsn, "1.6.0"},
     {applications, [kernel, stdlib]},
     {registered, [poolboy]},
 

--- a/src/poolboy.erl
+++ b/src/poolboy.erl
@@ -37,7 +37,7 @@
     overflow = 0 :: non_neg_integer(),
     max_overflow = 10 :: non_neg_integer(),
     strategy = lifo :: lifo | fifo,
-    overflow_check_period :: non_neg_integer(),
+    overflow_check_period :: non_neg_integer(), %milliseconds
     overflow_ttl = 0 :: non_neg_integer()   %microseconds
 }).
 
@@ -144,7 +144,7 @@ init([{strategy, fifo} | Rest], WorkerArgs, State) ->
 init([{overflow_ttl, OverflowTtl} | Rest], WorkerArgs, State) when is_integer(OverflowTtl) ->
     init(Rest, WorkerArgs, State#state{overflow_ttl = OverflowTtl * 1000});
 init([{overflow_check_period, OverflowCheckPeriod} | Rest], WorkerArgs, State) when is_integer(OverflowCheckPeriod) ->
-    init(Rest, WorkerArgs, State#state{overflow_check_period = OverflowCheckPeriod * 1000});
+    init(Rest, WorkerArgs, State#state{overflow_check_period = OverflowCheckPeriod});
 init([_ | Rest], WorkerArgs, State) ->
     init(Rest, WorkerArgs, State);
 init([], _WorkerArgs, #state{size = Size, supervisor = Sup} = State) ->

--- a/src/poolboy.erl
+++ b/src/poolboy.erl
@@ -130,7 +130,7 @@ init({PoolArgs, WorkerArgs}) ->
     Monitors = ets:new(monitors, [private]),
     init(PoolArgs, WorkerArgs, #state{waiting = Waiting, monitors = Monitors}).
 
-init([{worker_module, Mod} | Rest], WorkerArgs, State) when is_atom(Mod) ->
+init([{worker_module, Mod} | Rest], WorkerArgs, State) ->
     {ok, Sup} = poolboy_sup:start_link(Mod, WorkerArgs),
     init(Rest, WorkerArgs, State#state{supervisor = Sup});
 init([{size, Size} | Rest], WorkerArgs, State) when is_integer(Size) ->

--- a/src/poolboy.erl
+++ b/src/poolboy.erl
@@ -1,5 +1,4 @@
 %% Poolboy - A hunky Erlang worker pool factory
--include_lib("eunit/include/eunit.hrl").
 -module(poolboy).
 -behaviour(gen_server).
 
@@ -248,10 +247,8 @@ handle_info({'DOWN', MRef, _, _, _}, State) ->
 handle_info({'EXIT', Pid, _Reason}, State) ->
     #state{supervisor = Sup,
            monitors = Monitors,
-           workers_to_reap = WorkersToReap,
            workers = Workers} = State,
-
-    true = ets:delete(WorkersToReap, Pid),
+    ok = cancel_worker_reap(State, Pid),
     case ets:lookup(Monitors, Pid) of
         [{Pid, _, MRef}] ->
             true = erlang:demonitor(MRef),

--- a/src/poolboy_sup.erl
+++ b/src/poolboy_sup.erl
@@ -8,7 +8,11 @@
 start_link(Mod, Args) ->
     supervisor:start_link(?MODULE, {Mod, Args}).
 
-init({Mod, Args}) ->
+init({Mod, Args}) when is_atom(Mod)->
     {ok, {{simple_one_for_one, 0, 1},
           [{Mod, {Mod, start_link, [Args]},
+            temporary, 5000, worker, [Mod]}]}};
+init({{Mod, Fun}, Args}) ->
+    {ok, {{simple_one_for_one, 0, 1},
+        [{Mod, {Mod, Fun, [Args]},
             temporary, 5000, worker, [Mod]}]}}.

--- a/test/poolboy_tests.erl
+++ b/test/poolboy_tests.erl
@@ -390,7 +390,7 @@ pool_full_nonblocking() ->
     ok = pool_call(Pid, stop).
 
 pool_overflow_ttl_workers() ->
-    {ok, Pid} = new_pool_with_overflow_ttl(1, 1, 1000),
+    {ok, Pid} = new_pool_with_overflow_ttl(1, 1, 800),
     Worker = poolboy:checkout(Pid),
     Worker1 = poolboy:checkout(Pid),
     % Test pool behaves normally when full
@@ -428,7 +428,7 @@ pool_overflow_ttl_workers() ->
     ?assertEqual({ready, 2, 1, 0}, poolboy:status(Pid)),
     ?assertEqual(2, length(pool_call(Pid, get_all_workers))),
     % Test overflow worker is reaped in the correct time period
-    timer:sleep(850),
+    timer:sleep(1500),
     % Test overflow worker is reaped in the correct time period
     ?assertEqual({ready, 1, 0, 0}, poolboy:status(Pid)),
     % Test worker death behaviour


### PR DESCRIPTION
As discussed in https://github.com/devinus/poolboy/pull/83#issuecomment-224312388 I made improvements in zugolosian`s changes.
In https://github.com/zugolosian/poolboy/pull/1 all commits are discussed.
Summing up:
- overflow rip check is now hold periodically without mass timer creation
- use monotonic time instead of os:timestamp
- add improvement in case of lifo when checking old overflow workers
