### PR TITLE
Fix checkout stacktrace when noproc

### DIFF
--- a/src/poolboy.erl
+++ b/src/poolboy.erl
@@ -55,8 +55,9 @@ checkout(Pool, Block, Timeout) ->
         gen_server:call(Pool, {checkout, CRef, Block}, Timeout)
     catch
         Class:Reason ->
+            Stack = erlang:get_stacktrace(),
             gen_server:cast(Pool, {cancel_waiting, CRef}),
-            erlang:raise(Class, Reason, erlang:get_stacktrace())
+            erlang:raise(Class, Reason, Stack)
     end.
 
 -spec checkin(Pool :: pool(), Worker :: pid()) -> ok.


### PR DESCRIPTION
`gen_server:cast/2` can set the last stacktrace as it will catch the `badarg` if a locally named process is not registered.