### PR TITLE
Support child_spec map format.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ otp_release:
   - 19.3
   - 18.3
   - 17.4
-  - R16B03-1
 sudo: false
 script:
 - ./rebar3 do compile, dialyzer

--- a/src/poolboy.erl
+++ b/src/poolboy.erl
@@ -4,8 +4,8 @@
 -behaviour(gen_server).
 
 -export([checkout/1, checkout/2, checkout/3, checkin/2, transaction/2,
-         transaction/3, child_spec/2, child_spec/3, start/1, start/2,
-         start_link/1, start_link/2, stop/1, status/1]).
+         transaction/3, child_spec/2, child_spec/3, child_spec/4, start/1,
+         start/2, start_link/1, start_link/2, stop/1, status/1]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
          code_change/3]).
 -export_type([pool/0]).
@@ -96,8 +96,23 @@ child_spec(PoolId, PoolArgs) ->
                  WorkerArgs :: proplists:proplist())
     -> supervisor:child_spec().
 child_spec(PoolId, PoolArgs, WorkerArgs) ->
+    child_spec(PoolId, PoolArgs, WorkerArgs, tuple).
+
+-spec child_spec(PoolId :: term(),
+                 PoolArgs :: proplists:proplist(),
+                 WorkerArgs :: proplists:proplist(),
+                 ChildSpecFormat :: 'tuple' | 'map')
+    -> supervisor:child_spec().
+child_spec(PoolId, PoolArgs, WorkerArgs, tuple) ->
     {PoolId, {poolboy, start_link, [PoolArgs, WorkerArgs]},
-     permanent, 5000, worker, [poolboy]}.
+     permanent, 5000, worker, [poolboy]};
+child_spec(PoolId, PoolArgs, WorkerArgs, map) ->
+    #{id => PoolId,
+      start => {poolboy, start_link, [PoolArgs, WorkerArgs]},
+      restart => permanent,
+      shutdown => 5000,
+      type => worker,
+      modules => [poolboy]}.
 
 -spec start(PoolArgs :: proplists:proplist())
     -> start_ret().


### PR DESCRIPTION
A map is the current [preferred format for child specifications](http://erlang.org/doc/man/supervisor.html#child_spec). This change allows for easier interoperability with other libraries that does not support the old tuple format; for example the function `start_supervised/2` from Elixir's `ExUnit` library. Alternatively, the existing `child_spec` function could be modified to return a `map`, since it would still have the stated type.