### PR TITLE
allow for overflow worker start failure

### DIFF
--- a/test/poolboy_crash_worker.erl
+++ b/test/poolboy_crash_worker.erl
@@ -1,0 +1,7 @@
+-module(poolboy_crash_worker).
+-behaviour(poolboy_worker).
+
+-export([start_link/1]).
+
+start_link(_Args) ->
+    {error, not_starting}.


### PR DESCRIPTION
As described in #122, if an overflow worker was unable to start (which may always happen owing to circumstances), the `poolboy` `gen_server` would crash, because it invariably expects `{ok, Pid}` to be returned from `supervisor:start_child/2` in the `new_worker/1` function. That is even though the spec for the `poolboy_worker:start_link/1` callback function explicitly _allows_ `{error, term()}` to be returned.

This PR changes this in that it really allows error tuples to be returned from the worker start functions. If an overflow worker fails to start in response to a `checkout` or `transaction` request, an `exit` exception will be raised in the client instead. Failure to start a _residual_ worker on pool start, or restart of an exited residual worker, will still cause a crash of the pool as before. I think that is what is to be expected, and it can be provided for when needed with the other PR (#123) that I recently submitted.