### PR TITLE
Local Pool (manager) with Remote Workers + Configurable Worker collection

### DIFF
--- a/src/poolboy.erl
+++ b/src/poolboy.erl
@@ -308,10 +308,12 @@ handle_info({nodedown, Node}, State = #state{supervisor = {_, Node}}) ->
 handle_info(_Info, State) ->
     {noreply, State}.
 
-terminate(_Reason, State) ->
+terminate(_Reason, State = #state{supervisor = Sup}) ->
     Workers = queue:to_list(State#state.workers),
     ok = lists:foreach(fun (W) -> unlink(W) end, Workers),
-    true = exit(State#state.supervisor, shutdown),
+    if is_pid(Sup) -> true = exit(Sup, shutdown);
+       true -> ok = gen_server:stop(Sup)
+    end,
     ok.
 
 code_change(_OldVsn, State, _Extra) ->

--- a/src/poolboy.erl
+++ b/src/poolboy.erl
@@ -290,7 +290,7 @@ handle_call(status, _From, State) ->
            monitors = Monitors,
            overflow = Overflow} = State,
     StateName = state_name(State),
-    {reply, {StateName, poolboy_collection:len(visible, Workers), Overflow, ets:info(Monitors, size)}, State};
+    {reply, {StateName, poolboy_collection:length(visible, Workers), Overflow, ets:info(Monitors, size)}, State};
 handle_call(get_avail_workers, _From, State) ->
     {reply, poolboy_collection:all(visible, State#state.workers), State};
 handle_call(get_any_worker, _From, State) ->
@@ -421,7 +421,7 @@ handle_worker_exit(Pid, State) ->
 
 state_name(State = #state{overflow = Overflow}) when Overflow < 1 ->
     #state{max_overflow = MaxOverflow, workers = Workers} = State,
-    case poolboy_collection:len(visible, Workers) == 0 of
+    case poolboy_collection:length(visible, Workers) == 0 of
         true when MaxOverflow < 1 -> full;
         true -> overflow;
         false -> ready

--- a/src/poolboy.erl
+++ b/src/poolboy.erl
@@ -436,6 +436,8 @@ state_name(_State) ->
     overflow.
 
 stop_supervisor(_, undefined) -> ok;
+stop_supervisor(Reason, Atom) when is_atom(Atom) ->
+    stop_supervisor(Reason, whereis(Atom));
 stop_supervisor(Reason, Pid) when is_pid(Pid) ->
     case erlang:node(Pid) of
         N when N == node() -> exit(Pid, Reason);

--- a/src/poolboy.erl
+++ b/src/poolboy.erl
@@ -363,7 +363,11 @@ start_pool(StartFun, PoolArgs, WorkerArgs) ->
     end.
 
 new_worker(Sup) ->
-    {ok, Pid} = supervisor:start_child(Sup, []),
+    {ok, Pid} =
+    case is_atom(Sup) andalso erlang:function_exported(Sup, start_child, 0) of
+        true -> Sup:start_child();
+        false -> supervisor:start_child(Sup, [])
+    end,
     true = link(Pid),
     Pid.
 

--- a/src/poolboy.erl
+++ b/src/poolboy.erl
@@ -258,7 +258,7 @@ max_overflow(PoolArgs) ->
     Is = is_integer(V = proplists:get_value(max_overflow, PoolArgs)),
     if not Is -> ?DEFAULT_OVERFLOW; true -> V end.
 
--define(IS_STRATEGY(S), lists:member(S, [lifo, fifo])).
+-define(IS_STRATEGY(S), lists:member(S, [lifo, fifo, rand])).
 strategy(PoolArgs) ->
     Is = ?IS_STRATEGY(V = proplists:get_value(strategy, PoolArgs)),
     if not Is -> ?DEFAULT_STRATEGY; true -> V end.

--- a/src/poolboy.erl
+++ b/src/poolboy.erl
@@ -393,6 +393,8 @@ handle_info({'DOWN', MRef, _, _, _}, State) ->
             Waiting = queue:filter(fun ({_, _, R}) -> R =/= MRef end, State#state.waiting),
             {noreply, State#state{waiting = Waiting}}
     end;
+handle_info({'EXIT', _Pid, noconnection = Reason}, State) ->
+    {stop, Reason, State};
 handle_info({'EXIT', Pid, Reason}, State = #state{supervisor = Pid}) ->
     {stop, Reason, State};
 handle_info({'EXIT', Pid, _Reason}, State) ->

--- a/src/poolboy.erl
+++ b/src/poolboy.erl
@@ -228,8 +228,12 @@ worker_module(PoolArgs) ->
     if not Is -> undefined; true -> V end.
 
 worker_supervisor(PoolArgs) ->
-    Is = is_pid(Res = find_pid(V = proplists:get_value(worker_supervisor, PoolArgs))),
-    if not Is andalso Res =/= V -> exit({not_found, V, Res}); true -> Res end.
+    case find_pid(V = proplists:get_value(worker_supervisor, PoolArgs)) of
+        Res = undefined when Res =:= V -> Res;
+        Res when is_pid(Res) -> Res;
+        Res = undefined when Res =/= V -> exit({noproc, V});
+        Res -> exit({Res, V})
+    end.
 
 find_pid(undefined) ->
     undefined;
@@ -243,7 +247,13 @@ find_pid({via, Registry, Name}) ->
     Registry:whereis_name(Name);
 find_pid({Name, Node}) ->
     (catch erlang:monitor_node(Node, true)),
-    rpc:call(Node, erlang, whereis, [Name], ?TIMEOUT).
+    try rpc:call(Node, erlang, whereis, [Name], ?TIMEOUT) of
+        {badrpc, Reason} -> Reason;
+        Result -> Result
+    catch
+        _:Reason -> Reason
+    end.
+
 
 pool_size(PoolArgs) ->
     Is = is_integer(V = proplists:get_value(size, PoolArgs)),

--- a/src/poolboy.erl
+++ b/src/poolboy.erl
@@ -180,7 +180,8 @@ init([{size, Size} | Rest], WorkerArgs, State) when is_integer(Size) ->
     init(Rest, WorkerArgs, State#state{size = Size});
 init([{type, Type} | Rest], WorkerArgs, State) when Type == list orelse
                                                     Type == array orelse
-                                                    Type == tuple ->
+                                                    Type == tuple orelse
+                                                    Type == queue ->
     init(Rest, WorkerArgs, State#state{type = Type});
 init([{max_overflow, MaxOverflow} | Rest], WorkerArgs, State) when is_integer(MaxOverflow) ->
     init(Rest, WorkerArgs, State#state{max_overflow = MaxOverflow});
@@ -310,7 +311,7 @@ handle_info(_Info, State) ->
     {noreply, State}.
 
 terminate(Reason, State = #state{supervisor = Sup}) ->
-    ok = poolboy_collection:foreach(fun (W) -> catch unlink(W) end, State#state.workers),
+    poolboy_collection:filter(fun (W) -> catch not unlink(W) end, State#state.workers),
     stop_supervisor(Reason, Sup),
     ok.
 

--- a/src/poolboy.erl
+++ b/src/poolboy.erl
@@ -11,6 +11,14 @@
 -export_type([pool/0]).
 
 -define(TIMEOUT, 5000).
+-define(DEFAULT_SIZE, 5).
+-define(DEFAULT_TYPE, list).
+-define(IS_COLLECTION_TYPE(Type), (Type == list orelse
+                                   Type == array orelse
+                                   Type == tuple orelse
+                                   Type == queue)).
+
+
 
 -ifdef(OTP_RELEASE). %% this implies 21 or higher
 -define(EXCEPTION(Class, Reason, Stacktrace), Class:Reason:Stacktrace).
@@ -39,12 +47,11 @@
     pid().
 
 -record(state, {
-    supervisor :: undefined | sup_ref(),
+    supervisor :: sup_ref(),
     workers :: poolboy_collection:coll() | poolboy_collection:coll(pid()),
     waiting :: poolboy_collection:pid_queue() | poolboy_collection:pid_queue(tuple()),
     monitors :: ets:tid(),
-    size = 5 :: non_neg_integer(),
-    type = list :: list | array | tuple | queue,
+    size = ?DEFAULT_SIZE :: non_neg_integer(),
     overflow = 0 :: non_neg_integer(),
     max_overflow = 10 :: non_neg_integer(),
     strategy = lifo :: lifo | fifo
@@ -152,47 +159,76 @@ init({PoolArgs, WorkerArgs}) ->
     process_flag(trap_exit, true),
     Waiting = queue:new(),
     Monitors = ets:new(monitors, [private]),
-    init(PoolArgs, WorkerArgs, #state{waiting = Waiting, monitors = Monitors}).
+    Supervisor = ensure_worker_supervisor(PoolArgs, WorkerArgs),
+    Workers = prepopulate(PoolArgs, Supervisor),
+    init(PoolArgs, WorkerArgs,
+         #state{supervisor = Supervisor,
+                workers = Workers,
+                waiting = Waiting,
+                monitors = Monitors}).
 
-init([{worker_supervisor, Sup = {Scope, _Name}} | Rest], WorkerArgs, State)
-  when Scope =:= local orelse Scope =:= global ->
-    init(Rest, WorkerArgs, State#state{supervisor=Sup});
-init([{worker_supervisor, Sup = {_Name, Node}} | Rest], WorkerArgs, State) ->
-    (catch erlang:monitor_node(Node, true)),
-    init(Rest, WorkerArgs, State#state{supervisor=Sup});
-init([{worker_supervisor, Sup} | Rest], WorkerArgs, State)
-  when is_pid(Sup) orelse is_atom(Sup) orelse is_tuple(Sup) ->
-    init(Rest, WorkerArgs, State#state{supervisor=Sup});
-init([{worker_module, Mod} | Rest], WorkerArgs, State) when is_atom(Mod) ->
-    {ok, Sup} =
-    case poolboy_sup:start_link(Mod, WorkerArgs) of
-        {ok, _Pid} = Ok -> Ok;
-        {error, {already_started, Pid}} ->
+ensure_worker_supervisor(PoolArgs, WorkerArgs) ->
+    case proplists:get_value(worker_supervisor, PoolArgs) of
+        undefined ->
+            start_supervisor(
+              proplists:get_value(worker_module, PoolArgs),
+              WorkerArgs);
+        Sup = {Name, Node} when Name =/= local orelse
+                                Name =/= global ->
+            (catch erlang:monitor_node(Node, true)),
+            Sup;
+        Sup when is_pid(Sup) orelse
+                 is_atom(Sup) orelse
+                 is_tuple(Sup) ->
+            Sup
+    end.
+
+start_supervisor(WorkerModule, WorkerArgs) ->
+    start_supervisor(WorkerModule, WorkerArgs, 1).
+
+start_supervisor(undefined, _WorkerArgs, _Retries) ->
+    exit({no_worker_supervisor, {worker_module, undefined}});
+start_supervisor(WorkerModule, WorkerArgs, Retries) ->
+    case poolboy_sup:start_link(WorkerModule, WorkerArgs) of
+        {ok, NewPid} ->
+            NewPid;
+        {error, {already_started, Pid}} when Retries > 0 ->
             MRef = erlang:monitor(process, Pid),
-            receive
-                {'DOWN', MRef, _, _, _} -> ok
+            receive {'DOWN', MRef, _, _, _} -> ok
             after ?TIMEOUT -> ok
             end,
-            poolboy_sup:start_link(Mod, WorkerArgs)
-    end,
-    init(Rest, WorkerArgs, State#state{supervisor=Sup});
+            start_supervisor(WorkerModule, WorkerArgs, Retries - 1);
+        {error, Error} ->
+            exit({no_worker_supervisor, Error})
+    end.
+
+prepopulate(PoolArgs, Supervisor) ->
+    prepopulate(
+      proplists:get_value(size, PoolArgs, ?DEFAULT_SIZE),
+      proplists:get_value(type, PoolArgs, ?DEFAULT_TYPE),
+      Supervisor).
+
+prepopulate(Size, Type, Sup)
+  when is_integer(Size) andalso ?IS_COLLECTION_TYPE(Type) ->
+    poolboy_collection:new(Type, Size, fun(_) -> new_worker(Sup) end);
+prepopulate(Size, Type, Sup) when not is_integer(Size) ->
+    prepopulate(?DEFAULT_SIZE, Type, Sup);
+prepopulate(Size, Type, Sup) when not ?IS_COLLECTION_TYPE(Type) ->
+    prepopulate(Size, ?DEFAULT_TYPE, Sup).
+
 init([{size, Size} | Rest], WorkerArgs, State) when is_integer(Size) ->
     init(Rest, WorkerArgs, State#state{size = Size});
-init([{type, Type} | Rest], WorkerArgs, State) when Type == list orelse
-                                                    Type == array orelse
-                                                    Type == tuple orelse
-                                                    Type == queue ->
-    init(Rest, WorkerArgs, State#state{type = Type});
-init([{max_overflow, MaxOverflow} | Rest], WorkerArgs, State) when is_integer(MaxOverflow) ->
+init([{max_overflow, MaxOverflow} | Rest], WorkerArgs, State)
+  when is_integer(MaxOverflow) ->
     init(Rest, WorkerArgs, State#state{max_overflow = MaxOverflow});
-init([{strategy, lifo} | Rest], WorkerArgs, State) ->
-    init(Rest, WorkerArgs, State#state{strategy = lifo});
-init([{strategy, fifo} | Rest], WorkerArgs, State) ->
-    init(Rest, WorkerArgs, State#state{strategy = fifo});
+init([{strategy, Strategy} | Rest], WorkerArgs, State)
+  when Strategy == lifo orelse
+       Strategy == fifo ->
+    init(Rest, WorkerArgs, State#state{strategy = Strategy});
 init([_ | Rest], WorkerArgs, State) ->
     init(Rest, WorkerArgs, State);
-init([], _WorkerArgs, #state{size = Size, type=Type, supervisor = Sup} = State) ->
-    {ok, State#state{workers = prepopulate(Size, Type, Sup)}}.
+init([], _WorkerArgs, State) ->
+    {ok, State}.
 
 handle_cast({checkin, Pid}, State = #state{monitors = Monitors}) ->
     case ets:lookup(Monitors, Pid) of
@@ -296,7 +332,7 @@ handle_info({'EXIT', Pid, Reason}, State) ->
         [] ->
             try
                 {noreply, replace_worker(Pid, State)}
-            catch ?EXCEPTION(error, enoent, StackTrace) ->
+            catch ?EXCEPTION(error, enoent, _StackTrace) ->
                 {noreply, State}
             end
     end,
@@ -346,9 +382,6 @@ replace_worker(Pid, State = #state{strategy = Strategy}) ->
         lifo -> State#state{workers = poolboy_collection:prepend(NewWorker, Workers)};
         fifo -> State#state{workers = poolboy_collection:append(NewWorker, Workers)}
     end.
-
-prepopulate(Size, Type, Sup) ->
-    poolboy_collection:new(Type, Size, fun(_) -> new_worker(Sup) end).
 
 handle_checkin(Pid, State = #state{strategy = Strategy}) ->
     #state{supervisor = Sup,

--- a/src/poolboy.erl
+++ b/src/poolboy.erl
@@ -169,7 +169,7 @@ init({PoolArgs, WorkerArgs}) ->
         undefined ->
             start_supervisor(WorkerModule, WorkerArgs);
         Sup when is_pid(Sup) ->
-            true = link(Sup),
+            monitor(process, Sup),
             Sup
     end,
     Size = pool_size(PoolArgs),
@@ -372,6 +372,8 @@ handle_call(_Msg, _From, State) ->
     Reply = {error, invalid_message},
     {reply, Reply, State}.
 
+handle_info({'DOWN', _, process, Pid, Reason}, State = #state{supervisor = Pid}) ->
+    {stop, Reason, State};
 handle_info({'DOWN', MRef, _, _, _}, State) ->
     case ets:lookup(State#state.mrefs, MRef) of
         [{MRef, Pid}] ->

--- a/src/poolboy.erl
+++ b/src/poolboy.erl
@@ -12,7 +12,7 @@
 
 -define(TIMEOUT, 5000).
 -define(DEFAULT_SIZE, 5).
--define(DEFAULT_TYPE, list).
+-define(DEFAULT_TYPE, tuple).
 -define(DEFAULT_STRATEGY, lifo).
 -define(DEFAULT_OVERFLOW, 10).
 

--- a/src/poolboy_collection.erl
+++ b/src/poolboy_collection.erl
@@ -99,14 +99,14 @@
                      }
          }).
 
-from(Data, T) -> (T#type.?FUNCTION_NAME)(Data).
-is(Data, T) -> (T#type.?FUNCTION_NAME)(Data).
-len(Data, T) -> (T#type.?FUNCTION_NAME)(Data).
-nth(Index, Data, T) -> (T#type.?FUNCTION_NAME)(Index, Data).
-prep(In, Data, T) -> (T#type.?FUNCTION_NAME)(In, Data).
-app(In, Data, T) -> (T#type.?FUNCTION_NAME)(In, Data).
-filter(Fun, Data, T) -> (T#type.?FUNCTION_NAME)(Fun, Data).
-replace(In, Index, Out, Data, T) -> (T#type.?FUNCTION_NAME)(In, Index, Out, Data).
+from(Data, T) -> (T#type.from)(Data).
+is(Data, T) -> (T#type.is)(Data).
+len(Data, T) -> (T#type.len)(Data).
+nth(Index, Data, T) -> (T#type.nth)(Index, Data).
+prep(In, Data, T) -> (T#type.prep)(In, Data).
+app(In, Data, T) -> (T#type.app)(In, Data).
+filter(Fun, Data, T) -> (T#type.filter)(Fun, Data).
+replace(In, Index, Out, Data, T) -> (T#type.replace)(In, Index, Out, Data).
 
 
 new(Type, Size, Fun) when is_function(Fun, 1) ->

--- a/src/poolboy_collection.erl
+++ b/src/poolboy_collection.erl
@@ -1,7 +1,7 @@
 -module(poolboy_collection).
 
 -export([new/3,
-         len/2,
+         length/2,
          hide_head/1,
          replace/2, replace/3,
          prepend/2,
@@ -23,171 +23,150 @@
 -type coll_data() :: list()|{}|array:array()|pid_queue().
 -type coll_data(A) :: list(A)|{A}|array:array(A)|pid_queue(A).
 
--define(Types,
-        #{list => #{
-            is => fun is_list/1,
-            len => fun length/1,
-            from => fun(L) -> L end,
-            nth => fun lists:nth/2,
-            prep => fun(I, L) -> [I|L] end,
-            app => fun(I, L) -> L ++ [I] end,
-            filter => fun lists:filter/2,
-            replace => fun(O, X, I, L) ->
-                               {L1, [O | Tl]} = lists:split(X-1, L),
-                               L1 ++ [I| Tl]
-                       end
-           },
-          array => #{
-            is => fun array:is_array/1,
-            len => fun array:size/1,
-            from => fun array:from_list/1,
-            nth => fun(I, A) -> array:get(I-1, A) end,
-            prep => fun(I, A) -> array:foldl(
-                                   fun(Idx, Val, Arr) ->
-                                           array:set(Idx+1, Val, Arr)
-                                   end,
-                                   array:set(0, I, array:new()),
-                                   A)
-                    end,
-            app => fun(I, A) -> array:set(array:size(A), I, A) end,
-            filter => fun(Fun, A) ->
-                              array:sparse_map(
-                                fun(_, V) ->
-                                        case Fun(V) of
-                                            true -> V;
-                                            false -> array:default(A);
-                                            Else -> Else
-                                        end
-                                end, A)
-                      end,
-            replace => fun(O, X, I, A) ->
-                               O = array:get(X-1, A),
-                               array:set(X-1, I, A)
-                       end
-           },
-          queue => #{
-            is => fun queue:is_queue/1,
-            len => fun queue:len/1,
-            from => fun queue:from_list/1,
-            nth => fun(I, {_RL, FL})
-                         when I =< length(FL) ->
-                           lists:nth(I, FL);
-                      (I, {RL, FL}) ->
-                           lists:nth(
-                             length(RL)-(I-length(FL)-1),
-                             RL)
-                   end,
-            prep => fun queue:in_r/2,
-            app => fun queue:in/2,
-            filter => fun queue:filter/2,
-            replace => fun(O, X, I, Q) ->
-                               {Q1, Q2} = queue:split(X-1, Q),
-                               O = queue:get(Q2),
-                               queue:join(queue:in(I, Q1), queue:drop(Q2))
-                       end
-           },
-          tuple => #{
-            is => fun is_tuple/1,
-            len => fun tuple_size/1,
-            from => fun list_to_tuple/1,
-            nth => fun element/2,
-            prep => fun(I, Tu) ->  erlang:insert_element(1, Tu, I) end,
-            app => fun(I, Tu) -> erlang:append_element(Tu, I) end,
-            filter => fun(Fun, Tu) -> tuple_filter(Fun, Tu) end,
-            replace => fun(O, X, I, Tu) ->
-                               O = element(X, Tu),
-                               setelement(X, Tu, I)
-                       end
-           }
+-record(type, {
+          from :: fun((list(A)) -> coll_data(A)),
+          is :: fun((coll_data() | coll_data(any())) -> boolean()),
+          len :: fun((coll_data() | coll_data(any())) -> non_neg_integer()),
+          nth :: fun((non_neg_integer(), coll_data(A)) -> A),
+          prep :: fun((A, coll_data(A)) -> coll_data(A)),
+          app :: fun((A, coll_data(A)) -> coll_data(A)),
+          filter :: fun((fun((A) -> boolean()), coll_data(A)) -> coll_data(A)),
+          replace :: fun((A, non_neg_integer(), A, coll_data(A)) -> coll_data(A))
          }).
--define(Colls(Type, Fun), maps:get(Fun, maps:get(Type, ?Types))).
+-type type() :: #type{}.
 
+-record(coll, {
+          item_generator :: fun((non_neg_integer()) -> any()),
+          data :: coll_data() | coll_data(any()),
+          type :: type(),
+          indexes :: [non_neg_integer()],
+          rev_indexes :: #{any()=>non_neg_integer()}
+          }).
 
--record(coll, {indexes :: [non_neg_integer()],
-               rev_indexes :: #{any()=>non_neg_integer()},
-               data :: coll_data() | coll_data(any()),
-               item_generator :: fun((non_neg_integer()) -> any()) }).
-
--type coll() :: #coll{rev_indexes :: #{}, data :: coll_data()}.
--type coll(A) :: #coll{rev_indexes :: #{A=>non_neg_integer()},
-                       data :: coll_data(A),
-                       item_generator :: fun((non_neg_integer()) -> A) }.
+-type coll() :: #coll{
+                   data :: coll_data(),
+                   rev_indexes :: #{}
+                  }.
+-type coll(A) :: #coll{
+                    item_generator :: fun((non_neg_integer()) -> A),
+                    data :: coll_data(A),
+                    rev_indexes :: #{A=>non_neg_integer()}
+                    }.
 
 -export_type([coll/0, coll/1]).
 
+
+-define(TYPES, #{
+          list => #type{
+                     from = fun(L) -> L end,
+                     is = fun is_list/1,
+                     len = fun length/1,
+                     nth = fun lists:nth/2,
+                     prep = fun(I, L) -> [I|L] end,
+                     app = fun(I, L) -> L ++ [I] end,
+                     filter = fun lists:filter/2,
+                     replace = fun list_replace/4
+                    },
+          array => #type{
+                      from = fun array:from_list/1,
+                      is = fun array:is_array/1,
+                      len = fun array:size/1,
+                      nth = fun(I, A) -> array:get(I-1, A) end,
+                      prep = fun array_prep/2,
+                      app = fun(I, A) -> array:set(array:size(A), I, A) end,
+                      filter = fun array_filter/2,
+                      replace = fun array_replace/4
+                     },
+          queue => #type{
+                      from = fun queue:from_list/1,
+                      is = fun queue:is_queue/1,
+                      len = fun queue:len/1,
+                      nth = fun queue_nth/2,
+                      prep = fun queue:in_r/2,
+                      app = fun queue:in/2,
+                      filter = fun queue:filter/2,
+                      replace = fun queue_replace/4
+                     },
+          tuple => #type{
+                      from = fun list_to_tuple/1,
+                      is = fun is_tuple/1,
+                      len = fun tuple_size/1,
+                      nth = fun element/2,
+                      prep = fun(I, Tu) ->  erlang:insert_element(1, Tu, I) end,
+                      app = fun(I, Tu) -> erlang:append_element(Tu, I) end,
+                      filter = fun tuple_filter/2,
+                      replace = fun tuple_replace/4
+                     }
+         }).
+
+from(Data, T) -> (T#type.?FUNCTION_NAME)(Data).
+is(Data, T) -> (T#type.?FUNCTION_NAME)(Data).
+len(Data, T) -> (T#type.?FUNCTION_NAME)(Data).
+nth(Index, Data, T) -> (T#type.?FUNCTION_NAME)(Index, Data).
+prep(In, Data, T) -> (T#type.?FUNCTION_NAME)(In, Data).
+app(In, Data, T) -> (T#type.?FUNCTION_NAME)(In, Data).
+filter(Fun, Data, T) -> (T#type.?FUNCTION_NAME)(Fun, Data).
+replace(In, Index, Out, Data, T) -> (T#type.?FUNCTION_NAME)(In, Index, Out, Data).
+
+
 new(Type, Size, Fun) when is_function(Fun, 1) ->
+    CollType = maps:get(Type, ?TYPES),
     Indexes = lists:seq(1, Size),
     RevIndexes = maps:from_list([{Fun(I), I} || I <- Indexes]),
-    Data = (from(Type))(maps:keys(RevIndexes)),
-    #coll{indexes = Indexes, rev_indexes = RevIndexes, data = Data,
-          item_generator = Fun}.
+    #coll{
+       item_generator = Fun,
+       data = from(maps:keys(RevIndexes), CollType),
+       type = CollType,
+       indexes = Indexes,
+       rev_indexes = RevIndexes
+      }.
 
-from(Type) -> ?Colls(Type, ?FUNCTION_NAME).
 
-len(known, #coll{data=Data}) -> len(Data);
-len(visible, #coll{indexes=Indexes}) -> length(Indexes).
-
-len(Data) ->
-    (call(?FUNCTION_NAME, Data))(Data).
-
-call(F, Data) when is_atom(F) ->
-    call(F, Data, false, [none| maps:keys(?Types)]).
-
-call(F, _Data, true, [T |_Types]) -> ?Colls(T, F);
-call(F, Data, false, [_ | [T |_] = Types]) ->
-    call(F, Data, ?Colls(T, is), Types);
-call(F, Data, IsType, Types) when is_function(IsType, 1) ->
-    call(F, Data, IsType(Data), Types).
+length(known, #coll{data=Data, type=T}) -> len(Data, T);
+length(visible, #coll{indexes=Indexes}) -> length(Indexes).
 
 
 hide_head(#coll{indexes = []}) -> empty;
-hide_head(Coll = #coll{indexes = [H|T], data=Data}) ->
-    {nth(H, Data), Coll#coll{indexes = T}}.
+hide_head(Coll = #coll{indexes = [Hd|Tl], data=Data, type=T}) ->
+    {nth(Hd, Data, T), Coll#coll{indexes = Tl}}.
 
-nth(Index, Data) ->
-    (call(?FUNCTION_NAME, Data))(Index, Data).
 
 replace(Out, Coll = #coll{item_generator = In}) ->
     replace(Out, In, Coll).
 
-replace(Out, In, Coll = #coll{data = Data}) ->
+replace(Out, In, Coll) when not is_function(In, 1) ->
+    replace(Out, fun(_) -> In end, Coll);
+replace(Out, In, Coll = #coll{data = Data, type = T}) ->
     case maps:take(Out, Coll#coll.rev_indexes) of
         error -> error(enoent);
         {OutIndex, RevIndexes} ->
-            NewData = replace(OutIndex, Out, In, Data),
-            NewItem = nth(OutIndex, NewData),
+            NewData = replace(Out, OutIndex, In(OutIndex), Data, T),
+            NewItem = nth(OutIndex, NewData, T),
             NewRevIndexes = maps:put(NewItem, OutIndex, RevIndexes),
             {NewItem, Coll#coll{rev_indexes = NewRevIndexes, data = NewData}}
     end.
 
 
-replace(OutIndex, Out, In, Data) when not is_function(In) ->
-    replace(OutIndex, Out, fun(_) -> In end, Data);
-replace(OutIndex, Out, In, Data)  when is_function(In, 1)  ->
-    (call(?FUNCTION_NAME, Data))(Out, OutIndex, In(OutIndex), Data).
-
-
-prepend(In, Coll = #coll{indexes = Indexes, rev_indexes = RevIndexes, data = Data}) ->
+prepend(In, Coll = #coll{indexes = Indexes, rev_indexes = RevIndexes, data = Data, type = T}) ->
     case maps:get(In, RevIndexes, undefined) of
         InIndex when is_integer(InIndex) -> Coll#coll{indexes=[InIndex|Indexes]};
         undefined ->
-            NewData = prep(In, Data),
+            NewData = prep(In, Data, T),
             NewRevIndexes = maps:put(In, 1, maps:map(fun(_, V) -> V + 1 end, RevIndexes)),
             NewIndexes = [1 | [I+1 || I <- Indexes]],
             Coll#coll{indexes = NewIndexes, rev_indexes = NewRevIndexes, data = NewData}
     end.
 
-prep(In, Data) ->
-    (call(?FUNCTION_NAME, Data))(In, Data).
 
 
-append(In, Coll = #coll{indexes = Indexes, rev_indexes = RevIndexes, data = Data}) ->
+append(In, Coll = #coll{indexes = Indexes, rev_indexes = RevIndexes, data = Data, type = T}) ->
     case maps:get(In, RevIndexes, undefined) of
         InIndex when is_integer(InIndex) -> Coll#coll{indexes=Indexes++[InIndex]};
         undefined ->
-            NewData = app(In, Data),
+            NewData = app(In, Data, T),
+            ArrayT = maps:get(array, ?TYPES),
             NewIndex =
-            case {(?Colls(array, is))(Data), len(Data)} of
+            case {is(Data, ArrayT), len(Data, T)} of
                 {true, Len} -> Len - 1;
                 {_, Len} -> Len
             end,
@@ -196,12 +175,75 @@ append(In, Coll = #coll{indexes = Indexes, rev_indexes = RevIndexes, data = Data
             Coll#coll{indexes = NewIndexes, rev_indexes = NewRevIndexes, data = NewData}
     end.
 
-app(In, Data) ->
-    (call(?FUNCTION_NAME, Data))(In, Data).
+
+filter(Fun, #coll{data = Data, type = T}) ->
+    filter(Fun, Data, T).
 
 
-filter(Fun, #coll{data = Data}) ->
-    (call(?FUNCTION_NAME, Data))(Fun, Data).
+all(known, #coll{rev_indexes = RevIndexes}) ->
+    maps:keys(RevIndexes);
+all(visible, #coll{indexes = Indexes, data = Data, type = T}) ->
+    [nth(I, Data, T) || I <- Indexes].
+
+
+rand(known, #coll{data = Data, type = T}) ->
+    case len(Data, T) of
+        0 -> empty;
+        L -> nth(rand:uniform(L), Data, T)
+    end;
+rand(visible, #coll{indexes = []}) -> empty;
+rand(visible, #coll{indexes = Indexes, data = Data, type = T}) ->
+    nth(lists:nth(rand:uniform(length(Indexes)), Indexes), Data, T).
+
+
+
+
+
+list_replace(O, X, I, L) ->
+    {L1, [O | Tl]} = lists:split(X-1, L),
+    L1 ++ [I| Tl].
+
+
+
+array_prep(I, A) ->
+    array:foldl(
+      fun(Idx, Val, Arr) ->
+              array:set(Idx+1, Val, Arr)
+      end,
+      array:set(0, I, array:new()),
+      A).
+
+
+array_filter(F, A) ->
+    array:sparse_map(
+      fun(_, V) ->
+              case F(V) of
+                  true -> V;
+                  false -> array:default(A);
+                  Else -> Else
+              end
+      end,
+      A).
+
+
+array_replace(O, X, I, A) ->
+    O = array:get(X-1, A),
+    array:set(X-1, I, A).
+
+
+
+queue_nth(I, {_RL, FL}) when I =< length(FL) ->
+    lists:nth(I, FL);
+queue_nth(I, {RL, FL}) ->
+    J = length(RL)-(I-length(FL)-1),
+    lists:nth(J, RL).
+
+
+queue_replace(O, X, I, Q) ->
+    {Q1, Q2} = queue:split(X-1, Q),
+    O = queue:get(Q2),
+    queue:join(queue:in(I, Q1), queue:drop(Q2)).
+
 
 
 tuple_filter(Fun, Tuple) ->
@@ -219,17 +261,6 @@ tuple_filter(Fun, Tuple, Index) ->
     tuple_filter(Fun, NewTuple, Index-1).
 
 
-all(known, #coll{rev_indexes = RevIndexes}) ->
-    maps:keys(RevIndexes);
-all(visible, #coll{indexes = Indexes, data = Data}) ->
-    [nth(I, Data) || I <- Indexes].
-
-
-rand(known, #coll{data = Data}) ->
-    case len(Data) of
-        0 -> empty;
-        L -> nth(rand:uniform(L), Data)
-    end;
-rand(visible, #coll{indexes = []}) -> empty;
-rand(visible, #coll{indexes = Indexes, data = Data}) ->
-    nth(lists:nth(rand:uniform(length(Indexes)), Indexes), Data).
+tuple_replace(O, X, I, Tu) ->
+    O = element(X, Tu),
+    setelement(X, Tu, I).

--- a/src/poolboy_collection.erl
+++ b/src/poolboy_collection.erl
@@ -106,7 +106,7 @@ nth(Index, Data, T) -> (T#type.nth)(Index, Data).
 prep(In, Data, T) -> (T#type.prep)(In, Data).
 app(In, Data, T) -> (T#type.app)(In, Data).
 filter(Fun, Data, T) -> (T#type.filter)(Fun, Data).
-replace(In, Index, Out, Data, T) -> (T#type.replace)(In, Index, Out, Data).
+replace(Out, Index, In, Data, T) -> (T#type.replace)(Out, Index, In, Data).
 
 
 new(Type, Size, Fun) when is_function(Fun, 1) ->
@@ -141,8 +141,8 @@ replace(Out, In, Coll = #coll{data = Data, type = T}) ->
     case maps:take(Out, Coll#coll.rev_indexes) of
         error -> error(enoent);
         {OutIndex, RevIndexes} ->
-            NewData = replace(Out, OutIndex, In(OutIndex), Data, T),
-            NewItem = nth(OutIndex, NewData, T),
+            NewItem = In(OutIndex),
+            NewData = replace(Out, OutIndex, NewItem, Data, T),
             NewRevIndexes = maps:put(NewItem, OutIndex, RevIndexes),
             {NewItem, Coll#coll{rev_indexes = NewRevIndexes, data = NewData}}
     end.

--- a/src/poolboy_collection.erl
+++ b/src/poolboy_collection.erl
@@ -112,10 +112,11 @@ replace(In, Index, Out, Data, T) -> (T#type.?FUNCTION_NAME)(In, Index, Out, Data
 new(Type, Size, Fun) when is_function(Fun, 1) ->
     CollType = maps:get(Type, ?TYPES),
     Indexes = lists:seq(1, Size),
-    RevIndexes = maps:from_list([{Fun(I), I} || I <- Indexes]),
+    Items = [Fun(I) || I <- Indexes],
+    RevIndexes = maps:from_list(lists:zip(Items, Indexes)),
     #coll{
        item_generator = Fun,
-       data = from(maps:keys(RevIndexes), CollType),
+       data = from(Items, CollType),
        type = CollType,
        indexes = Indexes,
        rev_indexes = RevIndexes

--- a/src/poolboy_collection.erl
+++ b/src/poolboy_collection.erl
@@ -139,8 +139,9 @@ data_replace(OutIndex, Out, In, Data) when is_function(In, 1) andalso is_list(Da
 data_replace(OutIndex, Out, In, Data) when is_function(In, 1) andalso is_tuple(Data) ->
     case array:is_array(Data) of
         true ->
-            Out = array:get(OutIndex, Data),
-            array:set(OutIndex, In(OutIndex), Data);
+            ArrIndex = OutIndex-1,
+            Out = array:get(ArrIndex, Data),
+            array:set(ArrIndex, In(OutIndex), Data);
         false when element(OutIndex, Data) == Out ->
             setelement(OutIndex, Data, In(OutIndex))
     end.

--- a/src/poolboy_collection.erl
+++ b/src/poolboy_collection.erl
@@ -50,7 +50,7 @@
             is => fun queue:is_queue/1,
             len => fun queue:len/1,
             from => fun queue:from_list/1,
-            nth => fun(I, {RL, FL})
+            nth => fun(I, {_RL, FL})
                          when I =< length(FL) ->
                            lists:nth(I, FL);
                       (I, {RL, FL}) ->
@@ -66,11 +66,11 @@
             len => fun tuple_size/1,
             from => fun list_to_tuple/1,
             nth => fun element/2,
-            prep => fun(I, T) ->  erlang:insert_element(1, T, I) end,
-            app => fun(I, T) -> erlang:append_element(T, I) end
+            prep => fun(I, Tu) ->  erlang:insert_element(1, Tu, I) end,
+            app => fun(I, Tu) -> erlang:append_element(Tu, I) end
            }
          }).
--define(Colls(T, F), maps:get(F, maps:get(T, ?Types))).
+-define(Colls(Type, Fun), maps:get(Fun, maps:get(Type, ?Types))).
 
 
 -record(coll, {indexes :: [non_neg_integer()],
@@ -203,8 +203,8 @@ all(visible, #coll{indexes = Indexes, data = Data}) ->
 rand(known, #coll{data = Data}) ->
     case len(Data) of
         0 -> empty;
-        L -> nth(rand:uniform(1, L), Data)
+        L -> nth(rand:uniform(L), Data)
     end;
 rand(visible, #coll{indexes = []}) -> empty;
 rand(visible, #coll{indexes = Indexes, data = Data}) ->
-    nth(lists:nth(rand:uniform(1, length(Indexes)), Indexes), Data).
+    nth(lists:nth(rand:uniform(length(Indexes)), Indexes), Data).

--- a/src/poolboy_collection.erl
+++ b/src/poolboy_collection.erl
@@ -4,8 +4,8 @@
          length/2,
          hide_head/1,
          replace/2, replace/3,
-         prepend/2,
-         append/2,
+         lifo/2, prepend/2,
+         fifo/2, append/2,
          filter/2,
          all/2,
          rand/2
@@ -147,6 +147,7 @@ replace(Out, In, Coll = #coll{data = Data, type = T}) ->
             {NewItem, Coll#coll{rev_indexes = NewRevIndexes, data = NewData}}
     end.
 
+lifo(In, Coll) -> prepend(In, Coll).
 
 prepend(In, Coll = #coll{indexes = Indexes, rev_indexes = RevIndexes, data = Data, type = T}) ->
     case maps:get(In, RevIndexes, undefined) of
@@ -159,6 +160,7 @@ prepend(In, Coll = #coll{indexes = Indexes, rev_indexes = RevIndexes, data = Dat
     end.
 
 
+fifo(In, Coll) -> append(In, Coll).
 
 append(In, Coll = #coll{indexes = Indexes, rev_indexes = RevIndexes, data = Data, type = T}) ->
     case maps:get(In, RevIndexes, undefined) of

--- a/src/poolboy_collection.erl
+++ b/src/poolboy_collection.erl
@@ -133,7 +133,6 @@ len(Data) ->
 call(F, Data) when is_atom(F) ->
     call(F, Data, false, [none| maps:keys(?Types)]).
 
-call(_, _Data, _, []) -> throw(badarg);
 call(F, _Data, true, [T |_Types]) -> ?Colls(T, F);
 call(F, Data, false, [_ | [T |_] = Types]) ->
     call(F, Data, ?Colls(T, is), Types);

--- a/src/poolboy_collection.erl
+++ b/src/poolboy_collection.erl
@@ -1,0 +1,209 @@
+-module(poolboy_collection).
+
+-export([new/3,
+         len/2,
+         hide_head/1,
+         replace/2, replace/3,
+         prepend/2,
+         append/2,
+         foreach/2,
+         all/2,
+         rand/2
+        ]).
+
+-ifdef(pre17).
+-type pid_queue() :: queue().
+-type pid_queue(A) :: queue(A).
+-else.
+-type pid_queue() :: queue:queue().
+-type pid_queue(A) :: queue:queue(A).
+-endif.
+-export_type([pid_queue/0, pid_queue/1]).
+
+-type coll_data() :: list()|{}|array:array()|pid_queue().
+-type coll_data(A) :: list(A)|{A}|array:array(A)|pid_queue(A).
+
+-define(Types, 
+        #{list => #{
+            is => fun is_list/1,
+            len => fun length/1,
+            from => fun(L) -> L end,
+            nth => fun lists:nth/2,
+            prep => fun(I, L) -> [I|L] end,
+            app => fun(I, L) -> L ++ [I] end
+           },
+          array => #{
+            is => fun array:is_array/1,
+            len => fun array:size/1,
+            from => fun array:from_list/1,
+            nth => fun(I, A) -> array:get(I-1, A) end,
+            prep => fun(I, A) -> array:foldl(
+                                   fun(Idx, Val, Arr) ->
+                                           array:set(Idx+1, Val, Arr)
+                                   end,
+                                   array:set(0, I, array:new()),
+                                   A)
+                    end,
+            app => fun(I, A) -> array:set(array:size(A), I, A) end
+           },
+          queue => #{
+            is => fun queue:is_queue/1,
+            len => fun queue:len/1,
+            from => fun queue:from_list/1,
+            nth => fun(I, {RL, FL})
+                         when I =< length(FL) ->
+                           lists:nth(I, FL);
+                      (I, {RL, FL}) ->
+                           lists:nth(
+                             length(RL)-(I-length(FL)-1),
+                             RL)
+                   end,
+            prep => fun queue:in_r/2,
+            app => fun queue:in/2
+           },
+          tuple => #{
+            is => fun is_tuple/1,
+            len => fun tuple_size/1,
+            from => fun list_to_tuple/1,
+            nth => fun element/2,
+            prep => fun(I, T) ->  erlang:insert_element(1, T, I) end,
+            app => fun(I, T) -> erlang:append_element(T, I) end
+           }
+         }).
+-define(Colls(T, F), maps:get(F, maps:get(T, ?Types))).
+
+
+-record(coll, {indexes :: [non_neg_integer()],
+               rev_indexes :: #{any()=>non_neg_integer()},
+               data :: coll_data() | coll_data(any()),
+               item_generator :: fun((non_neg_integer()) -> any()) }).
+
+-type coll() :: #coll{rev_indexes :: #{}, data :: coll_data()}.
+-type coll(A) :: #coll{rev_indexes :: #{A=>non_neg_integer()},
+                       data :: coll_data(A),
+                       item_generator :: fun((non_neg_integer()) -> A) }.
+
+-export_type([coll/0, coll/1]).
+
+new(Type, Size, Fun) when is_function(Fun, 1) ->
+    Indexes = lists:seq(1, Size),
+    RevIndexes = maps:from_list([{Fun(I), I} || I <- Indexes]),
+    Data = (from(Type))(maps:keys(RevIndexes)),
+    #coll{indexes = Indexes, rev_indexes = RevIndexes, data = Data,
+          item_generator = Fun}.
+
+from(Type) -> ?Colls(Type, ?FUNCTION_NAME).
+
+len(known, #coll{data=Data}) -> len(Data);
+len(visible, #coll{indexes=Indexes}) -> length(Indexes).
+
+len(Data) ->
+    (call(?FUNCTION_NAME, Data))(Data).
+
+call(F, Data) when is_atom(F) ->
+    call(F, Data, false, [none| maps:keys(?Types)]).
+
+call(_, _Data, _, []) -> throw(badarg);
+call(F, _Data, true, [T |_Types]) -> ?Colls(T, F);
+call(F, Data, false, [_ | [T |_] = Types]) ->
+    call(F, Data, ?Colls(T, is), Types);
+call(F, Data, IsType, Types) when is_function(IsType, 1) ->
+    call(F, Data, IsType(Data), Types).
+
+
+hide_head(#coll{indexes = []}) -> empty;
+hide_head(Coll = #coll{indexes = [H|T], data=Data}) ->
+    {nth(H, Data), Coll#coll{indexes = T}}.
+
+nth(Index, Data) ->
+    (call(?FUNCTION_NAME, Data))(Index, Data).
+
+replace(Out, Coll = #coll{item_generator = In}) ->
+    replace(Out, In, Coll).
+
+replace(Out, In, Coll = #coll{data = Data}) ->
+    case maps:take(Out, Coll#coll.rev_indexes) of
+        error -> error(enoent);
+        {OutIndex, RevIndexes} ->
+            NewData = data_replace(OutIndex, Out, In, Data),
+            NewItem = nth(OutIndex, NewData),
+            NewRevIndexes = maps:put(NewItem, OutIndex, RevIndexes),
+            {NewItem, Coll#coll{rev_indexes = NewRevIndexes, data = NewData}}
+    end.
+
+data_replace(OutIndex, Out, In, Data) when not is_function(In) ->
+    data_replace(OutIndex, Out, fun(_) -> In end, Data);
+data_replace(OutIndex, Out, In, Data) when is_function(In, 1) andalso is_list(Data) ->
+    {FirstN, [Out | Tail]} = lists:split(OutIndex-1, Data),
+    FirstN ++ [In(OutIndex)| Tail];
+data_replace(OutIndex, Out, In, Data) when is_function(In, 1) andalso is_tuple(Data) ->
+    case array:is_array(Data) of
+        true ->
+            Out = array:get(OutIndex, Data),
+            array:set(OutIndex, In(OutIndex), Data);
+        false when element(OutIndex, Data) == Out ->
+            setelement(OutIndex, Data, In(OutIndex))
+    end.
+
+
+prepend(In, Coll = #coll{indexes = Indexes, rev_indexes = RevIndexes, data = Data}) ->
+    case maps:get(In, RevIndexes, undefined) of
+        InIndex when is_integer(InIndex) -> Coll#coll{indexes=[InIndex|Indexes]};
+        undefined ->
+            NewData = prep(In, Data),
+            NewRevIndexes = maps:put(In, 1, maps:map(fun(_, V) -> V + 1 end, RevIndexes)),
+            NewIndexes = [1 | [I+1 || I <- Indexes]],
+            Coll#coll{indexes = NewIndexes, rev_indexes = NewRevIndexes, data = NewData}
+    end.
+
+prep(In, Data) ->
+    (call(?FUNCTION_NAME, Data))(In, Data).
+
+append(In, Coll = #coll{indexes = Indexes, rev_indexes = RevIndexes, data = Data}) ->
+    case maps:get(In, RevIndexes, undefined) of
+        InIndex when is_integer(InIndex) -> Coll#coll{indexes=Indexes++[InIndex]};
+        undefined ->
+            NewData = app(In, Data),
+            NewIndex =
+            case {array:is_array(Data), len(Data)} of
+                {true, Len} -> Len - 1;
+                {_, Len} -> Len
+            end,
+            NewRevIndexes = maps:put(In, NewIndex, RevIndexes),
+            NewIndexes = Indexes++[NewIndex],
+            Coll#coll{indexes = NewIndexes, rev_indexes = NewRevIndexes, data = NewData}
+    end.
+
+app(In, Data) ->
+    (call(?FUNCTION_NAME, Data))(In, Data).
+
+foreach(Fun, #coll{data = Data}) -> data_foreach(Fun, Data).
+
+data_foreach(Fun, Data) when is_function(Fun) andalso is_list(Data) ->
+    lists:foreach(Fun, Data);
+data_foreach(Fun, Data) when is_function(Fun) andalso is_tuple(Data) ->
+    case array:is_array(Data) of
+        true -> array:sparse_map(fun(_, Value) -> Fun(Value) end, Data), ok;
+        false -> tuple_foreach(Fun, Data, erlang:tuple_size(Data))
+    end.
+
+tuple_foreach(_Fun, _Tuple, 0) -> ok;
+tuple_foreach(Fun, Tuple, Index) ->
+    Fun(element(Index, Tuple)),
+    tuple_foreach(Fun, Tuple, Index-1).
+
+
+all(known, #coll{rev_indexes = RevIndexes}) ->
+    maps:keys(RevIndexes);
+all(visible, #coll{indexes = Indexes, data = Data}) ->
+    [nth(I, Data) || I <- Indexes].
+
+
+rand(known, #coll{data = Data}) ->
+    case len(Data) of
+        0 -> empty;
+        L -> nth(rand:uniform(1, L), Data)
+    end;
+rand(visible, #coll{indexes = []}) -> empty;
+rand(visible, #coll{indexes = Indexes, data = Data}) ->
+    nth(lists:nth(rand:uniform(1, length(Indexes)), Indexes), Data).

--- a/src/poolboy_collection.erl
+++ b/src/poolboy_collection.erl
@@ -23,9 +23,14 @@
 -type coll_data() :: list()|{}|array:array()|pid_queue().
 -type coll_data(A) :: list(A)|{A}|array:array(A)|pid_queue(A).
 
+-record(typed_data, {
+          type :: 'list' |'array' |'queue' |'tuple',
+          data :: coll_data() | coll_data(any())
+         }).
+-type typed_data() :: #typed_data{data :: coll_data()}.
+-type typed_data(A) :: #typed_data{data :: coll_data(A)}.
+
 -record(type, {
-          from :: fun((list(A)) -> coll_data(A)),
-          is :: fun((coll_data() | coll_data(any())) -> boolean()),
           len :: fun((coll_data() | coll_data(any())) -> non_neg_integer()),
           nth :: fun((non_neg_integer(), coll_data(A)) -> A),
           prep :: fun((A, coll_data(A)) -> coll_data(A)),
@@ -33,63 +38,54 @@
           filter :: fun((fun((A) -> boolean()), coll_data(A)) -> coll_data(A)),
           replace :: fun((A, non_neg_integer(), A, coll_data(A)) -> coll_data(A))
          }).
--type type() :: #type{}.
 
 -record(coll, {
           item_generator :: fun((non_neg_integer()) -> any()),
-          data :: coll_data() | coll_data(any()),
-          type :: type(),
+          data :: typed_data() | typed_data(any()),
           indexes :: [non_neg_integer()],
           rev_indexes :: #{any()=>non_neg_integer()}
           }).
 
 -type coll() :: #coll{
-                   data :: coll_data(),
+                   data :: typed_data(),
                    rev_indexes :: #{}
                   }.
 -type coll(A) :: #coll{
                     item_generator :: fun((non_neg_integer()) -> A),
-                    data :: coll_data(A),
+                    data :: typed_data(A),
                     rev_indexes :: #{A=>non_neg_integer()}
                     }.
 
 -export_type([coll/0, coll/1]).
 
 
--define(TYPES, #{
-          list => #type{
-                     from = fun(L) -> L end,
-                     is = fun is_list/1,
+-define(TYPES(T),
+        case T of
+          list -> #type{
                      len = fun length/1,
                      nth = fun lists:nth/2,
                      prep = fun(I, L) -> [I|L] end,
                      app = fun(I, L) -> L ++ [I] end,
                      filter = fun lists:filter/2,
                      replace = fun list_replace/4
-                    },
-          array => #type{
-                      from = fun array:from_list/1,
-                      is = fun array:is_array/1,
+                    };
+          array -> #type{
                       len = fun array:size/1,
                       nth = fun(I, A) -> array:get(I-1, A) end,
                       prep = fun array_prep/2,
                       app = fun(I, A) -> array:set(array:size(A), I, A) end,
                       filter = fun array_filter/2,
                       replace = fun array_replace/4
-                     },
-          queue => #type{
-                      from = fun queue:from_list/1,
-                      is = fun queue:is_queue/1,
+                     };
+          queue -> #type{
                       len = fun queue:len/1,
                       nth = fun queue_nth/2,
                       prep = fun queue:in_r/2,
                       app = fun queue:in/2,
                       filter = fun queue:filter/2,
                       replace = fun queue_replace/4
-                     },
-          tuple => #type{
-                      from = fun list_to_tuple/1,
-                      is = fun is_tuple/1,
+                     };
+          tuple -> #type{
                       len = fun tuple_size/1,
                       nth = fun element/2,
                       prep = fun(I, Tu) ->  erlang:insert_element(1, Tu, I) end,
@@ -97,39 +93,52 @@
                       filter = fun tuple_filter/2,
                       replace = fun tuple_replace/4
                      }
-         }).
+        end).
 
-from(Data, T) -> (T#type.from)(Data).
-is(Data, T) -> (T#type.is)(Data).
-len(Data, T) -> (T#type.len)(Data).
-nth(Index, Data, T) -> (T#type.nth)(Index, Data).
-prep(In, Data, T) -> (T#type.prep)(In, Data).
-app(In, Data, T) -> (T#type.app)(In, Data).
-filter(Fun, Data, T) -> (T#type.filter)(Fun, Data).
-replace(Out, Index, In, Data, T) -> (T#type.replace)(Out, Index, In, Data).
+from(List, T) when T == list ->
+    #typed_data{type = T, data = List};
+from(List, T) when T == queue ->
+    #typed_data{type = T, data = queue:from_list(List)};
+from(List, T) when T == array ->
+    #typed_data{type = T, data = array:from_list(List)};
+from(List, T) when T == tuple ->
+    #typed_data{type = T, data = list_to_tuple(List)}.
+
+
+len(#typed_data{type = T, data = Data}) ->
+    (?TYPES(T)#type.len)(Data).
+nth(Index, #typed_data{type = T, data = Data}) ->
+    (?TYPES(T)#type.nth)(Index, Data).
+prep(In, TD = #typed_data{type = T, data = Data}) ->
+    TD#typed_data{data = (?TYPES(T)#type.prep)(In, Data)}.
+app(In, TD = #typed_data{type = T, data = Data}) ->
+    TD#typed_data{data = (?TYPES(T)#type.app)(In, Data)}.
+filter(Fun, #coll{data = Data}) -> filter(Fun, Data);
+filter(Fun, TD = #typed_data{type = T, data = Data}) ->
+    TD#typed_data{data = (?TYPES(T)#type.filter)(Fun, Data)}.
+replace(Out, Index, In, TD = #typed_data{type = T, data = Data}) ->
+    TD#typed_data{data = (?TYPES(T)#type.replace)(Out, Index, In, Data)}.
 
 
 new(Type, Size, Fun) when is_function(Fun, 1) ->
-    CollType = maps:get(Type, ?TYPES),
     Indexes = lists:seq(1, Size),
     Items = [Fun(I) || I <- Indexes],
     RevIndexes = maps:from_list(lists:zip(Items, Indexes)),
     #coll{
        item_generator = Fun,
-       data = from(Items, CollType),
-       type = CollType,
+       data = from(Items, Type),
        indexes = Indexes,
        rev_indexes = RevIndexes
       }.
 
 
-length(known, #coll{data=Data, type=T}) -> len(Data, T);
+length(known, #coll{data=Data}) -> len(Data);
 length(visible, #coll{indexes=Indexes}) -> length(Indexes).
 
 
 hide_head(#coll{indexes = []}) -> empty;
-hide_head(Coll = #coll{indexes = [Hd|Tl], data=Data, type=T}) ->
-    {nth(Hd, Data, T), Coll#coll{indexes = Tl}}.
+hide_head(Coll = #coll{indexes = [Hd|Tl], data=Data}) ->
+    {nth(Hd, Data), Coll#coll{indexes = Tl}}.
 
 
 replace(Out, Coll = #coll{item_generator = In}) ->
@@ -137,23 +146,23 @@ replace(Out, Coll = #coll{item_generator = In}) ->
 
 replace(Out, In, Coll) when not is_function(In, 1) ->
     replace(Out, fun(_) -> In end, Coll);
-replace(Out, In, Coll = #coll{data = Data, type = T}) ->
+replace(Out, In, Coll = #coll{data = Data}) ->
     case maps:take(Out, Coll#coll.rev_indexes) of
         error -> error(enoent);
         {OutIndex, RevIndexes} ->
             NewItem = In(OutIndex),
-            NewData = replace(Out, OutIndex, NewItem, Data, T),
+            NewData = replace(Out, OutIndex, NewItem, Data),
             NewRevIndexes = maps:put(NewItem, OutIndex, RevIndexes),
             {NewItem, Coll#coll{rev_indexes = NewRevIndexes, data = NewData}}
     end.
 
 lifo(In, Coll) -> prepend(In, Coll).
 
-prepend(In, Coll = #coll{indexes = Indexes, rev_indexes = RevIndexes, data = Data, type = T}) ->
+prepend(In, Coll = #coll{indexes = Indexes, rev_indexes = RevIndexes, data = Data}) ->
     case maps:get(In, RevIndexes, undefined) of
         InIndex when is_integer(InIndex) -> Coll#coll{indexes=[InIndex|Indexes]};
         undefined ->
-            NewData = prep(In, Data, T),
+            NewData = prep(In, Data),
             NewRevIndexes = maps:put(In, 1, maps:map(fun(_, V) -> V + 1 end, RevIndexes)),
             NewIndexes = [1 | [I+1 || I <- Indexes]],
             Coll#coll{indexes = NewIndexes, rev_indexes = NewRevIndexes, data = NewData}
@@ -162,15 +171,14 @@ prepend(In, Coll = #coll{indexes = Indexes, rev_indexes = RevIndexes, data = Dat
 
 fifo(In, Coll) -> append(In, Coll).
 
-append(In, Coll = #coll{indexes = Indexes, rev_indexes = RevIndexes, data = Data, type = T}) ->
+append(In, Coll = #coll{indexes = Indexes, rev_indexes = RevIndexes, data = Data}) ->
     case maps:get(In, RevIndexes, undefined) of
         InIndex when is_integer(InIndex) -> Coll#coll{indexes=Indexes++[InIndex]};
         undefined ->
-            NewData = app(In, Data, T),
-            ArrayT = maps:get(array, ?TYPES),
+            NewData = app(In, Data),
             NewIndex =
-            case {is(Data, ArrayT), len(Data, T)} of
-                {true, Len} -> Len - 1;
+            case {Data#typed_data.type, len(Data)} of
+                {array, Len} -> Len - 1;
                 {_, Len} -> Len
             end,
             NewRevIndexes = maps:put(In, NewIndex, RevIndexes),
@@ -179,24 +187,20 @@ append(In, Coll = #coll{indexes = Indexes, rev_indexes = RevIndexes, data = Data
     end.
 
 
-filter(Fun, #coll{data = Data, type = T}) ->
-    filter(Fun, Data, T).
-
-
 all(known, #coll{rev_indexes = RevIndexes}) ->
     maps:keys(RevIndexes);
-all(visible, #coll{indexes = Indexes, data = Data, type = T}) ->
-    [nth(I, Data, T) || I <- Indexes].
+all(visible, #coll{indexes = Indexes, data = Data}) ->
+    [nth(I, Data) || I <- Indexes].
 
 
-rand(known, #coll{data = Data, type = T}) ->
-    case len(Data, T) of
+rand(known, #coll{data = Data}) ->
+    case len(Data) of
         0 -> empty;
-        L -> nth(rand:uniform(L), Data, T)
+        L -> nth(rand:uniform(L), Data)
     end;
 rand(visible, #coll{indexes = []}) -> empty;
-rand(visible, #coll{indexes = Indexes, data = Data, type = T}) ->
-    nth(lists:nth(rand:uniform(length(Indexes)), Indexes), Data, T).
+rand(visible, #coll{indexes = Indexes, data = Data}) ->
+    nth(lists:nth(rand:uniform(length(Indexes)), Indexes), Data).
 
 
 
@@ -235,12 +239,14 @@ array_replace(O, X, I, A) ->
 
 
 
-queue_nth(I, {_RL, FL}) when I =< length(FL) ->
-    lists:nth(I, FL);
-queue_nth(I, {RL, FL}) ->
-    J = length(RL)-(I-length(FL)-1),
-    lists:nth(J, RL).
-
+queue_nth(I, Q) ->
+    case queue:is_queue(Q) of
+        true ->
+            {Q1, _Q2} = queue:split(I, Q),
+            queue:last(Q1);
+        _ ->
+            throw(badarg)
+    end.
 
 queue_replace(O, X, I, Q) ->
     {Q1, Q2} = queue:split(X-1, Q),

--- a/src/poolboy_sup.erl
+++ b/src/poolboy_sup.erl
@@ -6,7 +6,7 @@
 -export([start_link/2, init/1]).
 
 start_link(Mod, Args) ->
-    supervisor:start_link(?MODULE, {Mod, Args}).
+    supervisor:start_link({local, ?MODULE}, ?MODULE, {Mod, Args}).
 
 init({Mod, Args}) ->
     {ok, {{simple_one_for_one, 0, 1},

--- a/src/poolboy_sup.erl
+++ b/src/poolboy_sup.erl
@@ -6,7 +6,7 @@
 -export([start_link/2, init/1]).
 
 start_link(Mod, Args) ->
-    supervisor:start_link({local, ?MODULE}, ?MODULE, {Mod, Args}).
+    supervisor:start_link({local, Mod}, ?MODULE, {Mod, Args}).
 
 init({Mod, Args}) ->
     {ok, {{simple_one_for_one, 0, 1},

--- a/src/poolboy_worker_collection.erl
+++ b/src/poolboy_worker_collection.erl
@@ -1,0 +1,108 @@
+-module(poolboy_worker_collection).
+
+-export([new/3,
+         length/2,
+         hide_head/1,
+         replace/2, replace/3,
+         lifo/2, prepend/2,
+         fifo/2, append/2,
+         filter/2,
+         all/2,
+         rand/2
+        ]).
+
+
+-record(coll, {
+          item_generator :: fun((non_neg_integer()) -> any()),
+          data :: poolboy_collection:typed_data() | poolboy_collection:typed_data(any()),
+          indexes :: poolboy_collection:typed_data() | poolboy_collection:typed_data(any()),
+          rev_indexes :: #{any()=>non_neg_integer()}
+          }).
+
+-type coll() :: #coll{
+                   data :: poolboy_collection:typed_data(),
+                   rev_indexes :: #{}
+                  }.
+-type coll(A) :: #coll{
+                    item_generator :: fun((non_neg_integer()) -> A),
+                    data :: poolboy_collection:typed_data(A),
+                    rev_indexes :: #{A=>non_neg_integer()}
+                    }.
+
+-export_type([coll/0, coll/1]).
+
+
+new(Type, Size, Fun) when is_function(Fun, 1) ->
+    Indexes = lists:seq(1, Size),
+    Items = [Fun(I) || I <- Indexes],
+    RevIndexes = maps:from_list(lists:zip(Items, Indexes)),
+    #coll{
+       item_generator = Fun,
+       data = poolboy_collection:from(Items, Type),
+       indexes = poolboy_collection:from(Indexes, queue),
+       rev_indexes = RevIndexes
+      }.
+
+
+length(known, #coll{data=Data}) -> poolboy_collection:len(Data);
+length(visible, #coll{indexes=Indexes}) -> poolboy_collection:len(Indexes).
+
+
+hide_head(Coll = #coll{indexes = Indexes, data=Data}) ->
+    case poolboy_collection:out(Indexes) of
+        {empty, _} -> empty;
+        {{value, Hd}, Tl} ->
+            {poolboy_collection:nth(Hd, Data), Coll#coll{indexes = Tl}}
+    end.
+
+
+
+replace(Out, Coll = #coll{item_generator = In}) ->
+    replace(Out, In, Coll).
+
+replace(Out, In, Coll) when not is_function(In, 1) ->
+    replace(Out, fun(_) -> In end, Coll);
+replace(Out, In, Coll = #coll{data = Data}) ->
+    case maps:take(Out, Coll#coll.rev_indexes) of
+        error -> error(enoent);
+        {OutIndex, RevIndexes} ->
+            NewItem = In(OutIndex),
+            NewData = poolboy_collection:replace(Out, OutIndex, NewItem, Data),
+            NewRevIndexes = maps:put(NewItem, OutIndex, RevIndexes),
+            {NewItem, Coll#coll{rev_indexes = NewRevIndexes, data = NewData}}
+    end.
+
+lifo(In, Coll) -> prepend(In, Coll).
+
+prepend(In, Coll = #coll{indexes = Indexes, rev_indexes = RevIndexes, data = _Data}) ->
+    case maps:get(In, RevIndexes, undefined) of
+        InIndex when is_integer(InIndex) -> Coll#coll{indexes = poolboy_collection:prep(InIndex, Indexes)}
+    end.
+
+
+fifo(In, Coll) -> append(In, Coll).
+
+append(In, Coll = #coll{indexes = Indexes, rev_indexes = RevIndexes, data = _Data}) ->
+    case maps:get(In, RevIndexes, undefined) of
+        InIndex when is_integer(InIndex) -> Coll#coll{indexes = poolboy_collection:app(InIndex, Indexes)}
+    end.
+
+filter(Fun, #coll{data = Data}) ->
+    poolboy_collection:filter(Fun, Data).
+
+all(known, #coll{rev_indexes = RevIndexes}) ->
+    maps:keys(RevIndexes);
+all(visible, #coll{indexes = Indexes, data = Data}) ->
+    poolboy_collection:to(poolboy_collection:filter(fun(I) -> [poolboy_collection:nth(I, Data)] end, Indexes)).
+
+
+rand(known, #coll{data = Data}) ->
+    case poolboy_collection:len(Data) of
+        0 -> empty;
+        L -> poolboy_collection:nth(rand:uniform(L), Data)
+    end;
+rand(visible, #coll{indexes = Indexes, data = Data}) ->
+    case poolboy_collection:len(Indexes) of
+        0 -> empty;
+        L -> poolboy_collection:nth(poolboy_collection:nth(rand:uniform(L), Indexes), Data)
+    end.

--- a/src/poolboy_worker_collection.erl
+++ b/src/poolboy_worker_collection.erl
@@ -1,6 +1,6 @@
 -module(poolboy_worker_collection).
 
--export([new/3,
+-export([new/4,
          length/2,
          hide_head/1,
          replace/2, replace/3,
@@ -32,14 +32,16 @@
 -export_type([coll/0, coll/1]).
 
 
-new(Type, Size, Fun) when is_function(Fun, 1) ->
+new(Type, Size, lifo, Fun) -> new(Type, Size, list, Fun);
+new(Type, Size, fifo, Fun) -> new(Type, Size, queue, Fun);
+new(Type, Size, IndexesType, Fun) when is_function(Fun, 1) ->
     Indexes = lists:seq(1, Size),
     Items = [Fun(I) || I <- Indexes],
     RevIndexes = maps:from_list(lists:zip(Items, Indexes)),
     #coll{
        item_generator = Fun,
        data = poolboy_collection:from(Items, Type),
-       indexes = poolboy_collection:from(Indexes, queue),
+       indexes = poolboy_collection:from(Indexes, IndexesType),
        rev_indexes = RevIndexes
       }.
 

--- a/src/poolboy_worker_supervisor.erl
+++ b/src/poolboy_worker_supervisor.erl
@@ -4,3 +4,10 @@
                            {error, Reason} when
     Pid    :: pid(),
     Reason :: term().
+
+-callback start_child(integer()) -> {ok, Pid} |
+                                    {error, Reason} when
+    Pid    :: pid(),
+    Reason :: term().
+
+-optional_callbacks([start_child/0, start_child/1]).

--- a/src/poolboy_worker_supervisor.erl
+++ b/src/poolboy_worker_supervisor.erl
@@ -1,0 +1,6 @@
+-module(poolboy_worker_supervisor).
+
+-callback start_child() -> {ok, Pid} |
+                           {error, Reason} when
+    Pid    :: pid(),
+    Reason :: term().

--- a/test/poolboy_tests.erl
+++ b/test/poolboy_tests.erl
@@ -127,13 +127,13 @@ transaction_timeout() ->
 pool_startup() ->
     %% Check basic pool operation.
     {ok, Pid} = new_pool(10, 5),
-    ?assertEqual(10, queue:len(pool_call(Pid, get_avail_workers))),
+    ?assertEqual(10, length(pool_call(Pid, get_avail_workers))),
     poolboy:checkout(Pid),
-    ?assertEqual(9, queue:len(pool_call(Pid, get_avail_workers))),
+    ?assertEqual(9, length(pool_call(Pid, get_avail_workers))),
     Worker = poolboy:checkout(Pid),
-    ?assertEqual(8, queue:len(pool_call(Pid, get_avail_workers))),
+    ?assertEqual(8, length(pool_call(Pid, get_avail_workers))),
     checkin_worker(Pid, Worker),
-    ?assertEqual(9, queue:len(pool_call(Pid, get_avail_workers))),
+    ?assertEqual(9, length(pool_call(Pid, get_avail_workers))),
     ?assertEqual(1, length(pool_call(Pid, get_all_monitors))),
     ok = pool_call(Pid, stop).
 
@@ -141,23 +141,23 @@ pool_overflow() ->
     %% Check that the pool overflows properly.
     {ok, Pid} = new_pool(5, 5),
     Workers = [poolboy:checkout(Pid) || _ <- lists:seq(0, 6)],
-    ?assertEqual(0, queue:len(pool_call(Pid, get_avail_workers))),
+    ?assertEqual(0, length(pool_call(Pid, get_avail_workers))),
     ?assertEqual(7, length(pool_call(Pid, get_all_workers))),
     [A, B, C, D, E, F, G] = Workers,
     checkin_worker(Pid, A),
     checkin_worker(Pid, B),
-    ?assertEqual(0, queue:len(pool_call(Pid, get_avail_workers))),
+    ?assertEqual(0, length(pool_call(Pid, get_avail_workers))),
     ?assertEqual(5, length(pool_call(Pid, get_all_workers))),
     checkin_worker(Pid, C),
     checkin_worker(Pid, D),
-    ?assertEqual(2, queue:len(pool_call(Pid, get_avail_workers))),
+    ?assertEqual(2, length(pool_call(Pid, get_avail_workers))),
     ?assertEqual(5, length(pool_call(Pid, get_all_workers))),
     checkin_worker(Pid, E),
     checkin_worker(Pid, F),
-    ?assertEqual(4, queue:len(pool_call(Pid, get_avail_workers))),
+    ?assertEqual(4, length(pool_call(Pid, get_avail_workers))),
     ?assertEqual(5, length(pool_call(Pid, get_all_workers))),
     checkin_worker(Pid, G),
-    ?assertEqual(5, queue:len(pool_call(Pid, get_avail_workers))),
+    ?assertEqual(5, length(pool_call(Pid, get_avail_workers))),
     ?assertEqual(5, length(pool_call(Pid, get_all_workers))),
     ?assertEqual(0, length(pool_call(Pid, get_all_monitors))),
     ok = pool_call(Pid, stop).
@@ -167,7 +167,7 @@ pool_empty() ->
     %% overflow is enabled.
     {ok, Pid} = new_pool(5, 2),
     Workers = [poolboy:checkout(Pid) || _ <- lists:seq(0, 6)],
-    ?assertEqual(0, queue:len(pool_call(Pid, get_avail_workers))),
+    ?assertEqual(0, length(pool_call(Pid, get_avail_workers))),
     ?assertEqual(7, length(pool_call(Pid, get_all_workers))),
     [A, B, C, D, E, F, G] = Workers,
     Self = self(),
@@ -192,18 +192,18 @@ pool_empty() ->
     after
         500 -> ?assert(false)
     end,
-    ?assertEqual(0, queue:len(pool_call(Pid, get_avail_workers))),
+    ?assertEqual(0, length(pool_call(Pid, get_avail_workers))),
     ?assertEqual(5, length(pool_call(Pid, get_all_workers))),
     checkin_worker(Pid, C),
     checkin_worker(Pid, D),
-    ?assertEqual(2, queue:len(pool_call(Pid, get_avail_workers))),
+    ?assertEqual(2, length(pool_call(Pid, get_avail_workers))),
     ?assertEqual(5, length(pool_call(Pid, get_all_workers))),
     checkin_worker(Pid, E),
     checkin_worker(Pid, F),
-    ?assertEqual(4, queue:len(pool_call(Pid, get_avail_workers))),
+    ?assertEqual(4, length(pool_call(Pid, get_avail_workers))),
     ?assertEqual(5, length(pool_call(Pid, get_all_workers))),
     checkin_worker(Pid, G),
-    ?assertEqual(5, queue:len(pool_call(Pid, get_avail_workers))),
+    ?assertEqual(5, length(pool_call(Pid, get_avail_workers))),
     ?assertEqual(5, length(pool_call(Pid, get_all_workers))),
     ?assertEqual(0, length(pool_call(Pid, get_all_monitors))),
     ok = pool_call(Pid, stop).
@@ -213,7 +213,7 @@ pool_empty_no_overflow() ->
     %% disabled.
     {ok, Pid} = new_pool(5, 0),
     Workers = [poolboy:checkout(Pid) || _ <- lists:seq(0, 4)],
-    ?assertEqual(0, queue:len(pool_call(Pid, get_avail_workers))),
+    ?assertEqual(0, length(pool_call(Pid, get_avail_workers))),
     ?assertEqual(5, length(pool_call(Pid, get_all_workers))),
     [A, B, C, D, E] = Workers,
     Self = self(),
@@ -238,14 +238,14 @@ pool_empty_no_overflow() ->
     after
         500 -> ?assert(false)
     end,
-    ?assertEqual(2, queue:len(pool_call(Pid, get_avail_workers))),
+    ?assertEqual(2, length(pool_call(Pid, get_avail_workers))),
     ?assertEqual(5, length(pool_call(Pid, get_all_workers))),
     checkin_worker(Pid, C),
     checkin_worker(Pid, D),
-    ?assertEqual(4, queue:len(pool_call(Pid, get_avail_workers))),
+    ?assertEqual(4, length(pool_call(Pid, get_avail_workers))),
     ?assertEqual(5, length(pool_call(Pid, get_all_workers))),
     checkin_worker(Pid, E),
-    ?assertEqual(5, queue:len(pool_call(Pid, get_avail_workers))),
+    ?assertEqual(5, length(pool_call(Pid, get_avail_workers))),
     ?assertEqual(5, length(pool_call(Pid, get_all_workers))),
     ?assertEqual(0, length(pool_call(Pid, get_all_monitors))),
     ok = pool_call(Pid, stop).
@@ -256,16 +256,16 @@ worker_death() ->
     {ok, Pid} = new_pool(5, 2),
     Worker = poolboy:checkout(Pid),
     kill_worker(Worker),
-    ?assertEqual(5, queue:len(pool_call(Pid, get_avail_workers))),
+    ?assertEqual(5, length(pool_call(Pid, get_avail_workers))),
     [A, B, C|_Workers] = [poolboy:checkout(Pid) || _ <- lists:seq(0, 6)],
-    ?assertEqual(0, queue:len(pool_call(Pid, get_avail_workers))),
+    ?assertEqual(0, length(pool_call(Pid, get_avail_workers))),
     ?assertEqual(7, length(pool_call(Pid, get_all_workers))),
     kill_worker(A),
-    ?assertEqual(0, queue:len(pool_call(Pid, get_avail_workers))),
+    ?assertEqual(0, length(pool_call(Pid, get_avail_workers))),
     ?assertEqual(6, length(pool_call(Pid, get_all_workers))),
     kill_worker(B),
     kill_worker(C),
-    ?assertEqual(1, queue:len(pool_call(Pid, get_avail_workers))),
+    ?assertEqual(1, length(pool_call(Pid, get_avail_workers))),
     ?assertEqual(5, length(pool_call(Pid, get_all_workers))),
     ?assertEqual(4, length(pool_call(Pid, get_all_monitors))),
     ok = pool_call(Pid, stop).
@@ -277,9 +277,9 @@ worker_death_while_full() ->
     {ok, Pid} = new_pool(5, 2),
     Worker = poolboy:checkout(Pid),
     kill_worker(Worker),
-    ?assertEqual(5, queue:len(pool_call(Pid, get_avail_workers))),
+    ?assertEqual(5, length(pool_call(Pid, get_avail_workers))),
     [A, B|_Workers] = [poolboy:checkout(Pid) || _ <- lists:seq(0, 6)],
-    ?assertEqual(0, queue:len(pool_call(Pid, get_avail_workers))),
+    ?assertEqual(0, length(pool_call(Pid, get_avail_workers))),
     ?assertEqual(7, length(pool_call(Pid, get_all_workers))),
     Self = self(),
     spawn(fun() ->
@@ -306,7 +306,7 @@ worker_death_while_full() ->
         1000 -> ?assert(false)
     end,
     kill_worker(B),
-    ?assertEqual(0, queue:len(pool_call(Pid, get_avail_workers))),
+    ?assertEqual(0, length(pool_call(Pid, get_avail_workers))),
     ?assertEqual(6, length(pool_call(Pid, get_all_workers))),
     ?assertEqual(6, length(pool_call(Pid, get_all_monitors))),
     ok = pool_call(Pid, stop).
@@ -318,9 +318,9 @@ worker_death_while_full_no_overflow() ->
     {ok, Pid} = new_pool(5, 0),
     Worker = poolboy:checkout(Pid),
     kill_worker(Worker),
-    ?assertEqual(5, queue:len(pool_call(Pid, get_avail_workers))),
+    ?assertEqual(5, length(pool_call(Pid, get_avail_workers))),
     [A, B, C|_Workers] = [poolboy:checkout(Pid) || _ <- lists:seq(0, 4)],
-    ?assertEqual(0, queue:len(pool_call(Pid, get_avail_workers))),
+    ?assertEqual(0, length(pool_call(Pid, get_avail_workers))),
     ?assertEqual(5, length(pool_call(Pid, get_all_workers))),
     Self = self(),
     spawn(fun() ->
@@ -346,10 +346,10 @@ worker_death_while_full_no_overflow() ->
         1000 -> ?assert(false)
     end,
     kill_worker(B),
-    ?assertEqual(1, queue:len(pool_call(Pid, get_avail_workers))),
+    ?assertEqual(1, length(pool_call(Pid, get_avail_workers))),
     ?assertEqual(5, length(pool_call(Pid, get_all_workers))),
     kill_worker(C),
-    ?assertEqual(2, queue:len(pool_call(Pid, get_avail_workers))),
+    ?assertEqual(2, length(pool_call(Pid, get_avail_workers))),
     ?assertEqual(5, length(pool_call(Pid, get_all_workers))),
     ?assertEqual(3, length(pool_call(Pid, get_all_monitors))),
     ok = pool_call(Pid, stop).
@@ -359,7 +359,7 @@ pool_full_nonblocking_no_overflow() ->
     %% option to use non-blocking checkouts is used.
     {ok, Pid} = new_pool(5, 0),
     Workers = [poolboy:checkout(Pid) || _ <- lists:seq(0, 4)],
-    ?assertEqual(0, queue:len(pool_call(Pid, get_avail_workers))),
+    ?assertEqual(0, length(pool_call(Pid, get_avail_workers))),
     ?assertEqual(5, length(pool_call(Pid, get_all_workers))),
     ?assertEqual(full, poolboy:checkout(Pid, false)),
     ?assertEqual(full, poolboy:checkout(Pid, false)),
@@ -374,7 +374,7 @@ pool_full_nonblocking() ->
     %% option to use non-blocking checkouts is used.
     {ok, Pid} = new_pool(5, 5),
     Workers = [poolboy:checkout(Pid) || _ <- lists:seq(0, 9)],
-    ?assertEqual(0, queue:len(pool_call(Pid, get_avail_workers))),
+    ?assertEqual(0, length(pool_call(Pid, get_avail_workers))),
     ?assertEqual(10, length(pool_call(Pid, get_all_workers))),
     ?assertEqual(full, poolboy:checkout(Pid, false)),
     A = hd(Workers),
@@ -395,17 +395,17 @@ owner_death() ->
         receive after 500 -> exit(normal) end
     end),
     timer:sleep(1000),
-    ?assertEqual(5, queue:len(pool_call(Pid, get_avail_workers))),
+    ?assertEqual(5, length(pool_call(Pid, get_avail_workers))),
     ?assertEqual(5, length(pool_call(Pid, get_all_workers))),
     ?assertEqual(0, length(pool_call(Pid, get_all_monitors))),
     ok = pool_call(Pid, stop).
 
 checkin_after_exception_in_transaction() ->
     {ok, Pool} = new_pool(2, 0),
-    ?assertEqual(2, queue:len(pool_call(Pool, get_avail_workers))),
+    ?assertEqual(2, length(pool_call(Pool, get_avail_workers))),
     Tx = fun(Worker) ->
         ?assert(is_pid(Worker)),
-        ?assertEqual(1, queue:len(pool_call(Pool, get_avail_workers))),
+        ?assertEqual(1, length(pool_call(Pool, get_avail_workers))),
         throw(it_on_the_ground),
         ?assert(false)
     end,
@@ -414,7 +414,7 @@ checkin_after_exception_in_transaction() ->
     catch
         throw:it_on_the_ground -> ok
     end,
-    ?assertEqual(2, queue:len(pool_call(Pool, get_avail_workers))),
+    ?assertEqual(2, length(pool_call(Pool, get_avail_workers))),
     ok = pool_call(Pool, stop).
 
 pool_returns_status() ->

--- a/test/poolboy_tests.erl
+++ b/test/poolboy_tests.erl
@@ -532,13 +532,13 @@ rand_strategy({Type, rand}) ->
           Worker = poolboy:checkout(Pid),
           ok = poolboy:checkin(Pid, Worker),
           Worker
-      end || _ <- lists:seq(1,5) ],
+      end || _ <- lists:seq(1,9) ],
     Workers2 =
     [ begin
           Worker = poolboy:checkout(Pid),
           ok = poolboy:checkin(Pid, Worker),
           Worker
-      end || _ <- lists:seq(1,5) ],
+      end || _ <- lists:seq(1,9) ],
     ?assertNotEqual(Workers1, Workers2),
     Workers = [ poolboy:checkout(Pid)
                 || _ <- lists:seq(1,3) ],

--- a/test/poolboy_tests.erl
+++ b/test/poolboy_tests.erl
@@ -17,7 +17,7 @@ pool_test_() ->
         [ {Type,
            fun(T, _) ->
                    {<<(atom_to_binary(T, latin1))/binary, <<": ">>/binary, Title/binary>>, fun() -> Test(T) end}
-           end} || Type <- [list, array, tuple], {Title, Test} <-
+           end} || Type <- [list, array, tuple, queue], {Title, Test} <-
         [
             {<<"Basic pool operations">>,
                 fun pool_startup/1

--- a/test/poolboy_tests.erl
+++ b/test/poolboy_tests.erl
@@ -3,76 +3,83 @@
 -include_lib("eunit/include/eunit.hrl").
 
 pool_test_() ->
-    {foreach,
-        fun() ->
+    {foreachx,
+        fun(_) ->
             error_logger:tty(false)
         end,
-        fun(_) ->
+        fun(_, _) ->
             case whereis(poolboy_test) of
                 undefined -> ok;
                 Pid -> pool_call(Pid, stop)
             end,
             error_logger:tty(true)
         end,
+        [ {Type,
+           fun(T, _) ->
+                   {<<(atom_to_binary(T, latin1))/binary, <<": ">>/binary, Title/binary>>, fun() -> Test(T) end}
+           end} || Type <- [list, array, tuple], {Title, Test} <-
         [
             {<<"Basic pool operations">>,
-                fun pool_startup/0
+                fun pool_startup/1
             },
             {<<"Pool overflow should work">>,
-                fun pool_overflow/0
+                fun pool_overflow/1
             },
             {<<"Pool behaves when empty">>,
-                fun pool_empty/0
+                fun pool_empty/1
             },
             {<<"Pool behaves when empty and oveflow is disabled">>,
-                fun pool_empty_no_overflow/0
+                fun pool_empty_no_overflow/1
             },
             {<<"Pool behaves on worker death">>,
-                fun worker_death/0
+                fun worker_death/1
             },
             {<<"Pool behaves when full and a worker dies">>,
-                fun worker_death_while_full/0
+                fun worker_death_while_full/1
             },
             {<<"Pool behaves when full, a worker dies and overflow disabled">>,
-                fun worker_death_while_full_no_overflow/0
+                fun worker_death_while_full_no_overflow/1
             },
             {<<"Non-blocking pool behaves when full and overflow disabled">>,
-                fun pool_full_nonblocking_no_overflow/0
+                fun pool_full_nonblocking_no_overflow/1
             },
             {<<"Non-blocking pool behaves when full">>,
-                fun pool_full_nonblocking/0
+                fun pool_full_nonblocking/1
             },
             {<<"Pool behaves on owner death">>,
-                fun owner_death/0
+                fun owner_death/1
             },
             {<<"Worker checked-in after an exception in a transaction">>,
-                fun checkin_after_exception_in_transaction/0
+                fun checkin_after_exception_in_transaction/1
             },
             {<<"Pool returns status">>,
-                fun pool_returns_status/0
+                fun pool_returns_status/1
             },
             {<<"Pool demonitors previously waiting processes">>,
-                fun demonitors_previously_waiting_processes/0
+                fun demonitors_previously_waiting_processes/1
             },
             {<<"Pool demonitors when a checkout is cancelled">>,
-                fun demonitors_when_checkout_cancelled/0
+                fun demonitors_when_checkout_cancelled/1
             },
             {<<"Check that LIFO is the default strategy">>,
-                fun default_strategy_lifo/0
+                fun default_strategy_lifo/1
             },
             {<<"Check LIFO strategy">>,
-                fun lifo_strategy/0
+                fun lifo_strategy/1
             },
             {<<"Check FIFO strategy">>,
-                fun fifo_strategy/0
+                fun fifo_strategy/1
             },
             {<<"Pool reuses waiting monitor when a worker exits">>,
-                fun reuses_waiting_monitor_on_worker_exit/0
+                fun reuses_waiting_monitor_on_worker_exit/1
             },
             {<<"Recover from timeout without exit handling">>,
-                fun transaction_timeout_without_exit/0},
+                fun transaction_timeout_without_exit/1
+            },
             {<<"Recover from transaction timeout">>,
-                fun transaction_timeout/0}
+                fun transaction_timeout/1
+            }
+        ]
         ]
     }.
 
@@ -93,8 +100,8 @@ checkin_worker(Pid, Worker) ->
     timer:sleep(500).
 
 
-transaction_timeout_without_exit() ->
-    {ok, Pid} = new_pool(1, 0),
+transaction_timeout_without_exit(Type) ->
+    {ok, Pid} = new_pool(1, 0, lifo, Type),
     ?assertEqual({ready,1,0,0}, pool_call(Pid, status)),
     WorkerList = pool_call(Pid, get_all_workers),
     ?assertMatch([_], WorkerList),
@@ -108,8 +115,8 @@ transaction_timeout_without_exit() ->
     ?assertEqual({ready,1,0,0}, pool_call(Pid, status)).
 
 
-transaction_timeout() ->
-    {ok, Pid} = new_pool(1, 0),
+transaction_timeout(Type) ->
+    {ok, Pid} = new_pool(1, 0, lifo, Type),
     ?assertEqual({ready,1,0,0}, pool_call(Pid, status)),
     WorkerList = pool_call(Pid, get_all_workers),
     ?assertMatch([_], WorkerList),
@@ -124,9 +131,9 @@ transaction_timeout() ->
     ?assertEqual({ready,1,0,0}, pool_call(Pid, status)).
 
 
-pool_startup() ->
+pool_startup(Type) ->
     %% Check basic pool operation.
-    {ok, Pid} = new_pool(10, 5),
+    {ok, Pid} = new_pool(10, 5, lifo, Type),
     ?assertEqual(10, length(pool_call(Pid, get_avail_workers))),
     poolboy:checkout(Pid),
     ?assertEqual(9, length(pool_call(Pid, get_avail_workers))),
@@ -137,9 +144,9 @@ pool_startup() ->
     ?assertEqual(1, length(pool_call(Pid, get_all_monitors))),
     ok = pool_call(Pid, stop).
 
-pool_overflow() ->
+pool_overflow(Type) ->
     %% Check that the pool overflows properly.
-    {ok, Pid} = new_pool(5, 5),
+    {ok, Pid} = new_pool(5, 5, lifo, Type),
     Workers = [poolboy:checkout(Pid) || _ <- lists:seq(0, 6)],
     ?assertEqual(0, length(pool_call(Pid, get_avail_workers))),
     ?assertEqual(7, length(pool_call(Pid, get_all_workers))),
@@ -162,10 +169,10 @@ pool_overflow() ->
     ?assertEqual(0, length(pool_call(Pid, get_all_monitors))),
     ok = pool_call(Pid, stop).
 
-pool_empty() ->
+pool_empty(Type) ->
     %% Checks that the the pool handles the empty condition correctly when
     %% overflow is enabled.
-    {ok, Pid} = new_pool(5, 2),
+    {ok, Pid} = new_pool(5, 2, lifo, Type),
     Workers = [poolboy:checkout(Pid) || _ <- lists:seq(0, 6)],
     ?assertEqual(0, length(pool_call(Pid, get_avail_workers))),
     ?assertEqual(7, length(pool_call(Pid, get_all_workers))),
@@ -208,10 +215,10 @@ pool_empty() ->
     ?assertEqual(0, length(pool_call(Pid, get_all_monitors))),
     ok = pool_call(Pid, stop).
 
-pool_empty_no_overflow() ->
+pool_empty_no_overflow(Type) ->
     %% Checks the pool handles the empty condition properly when overflow is
     %% disabled.
-    {ok, Pid} = new_pool(5, 0),
+    {ok, Pid} = new_pool(5, 0, lifo, Type),
     Workers = [poolboy:checkout(Pid) || _ <- lists:seq(0, 4)],
     ?assertEqual(0, length(pool_call(Pid, get_avail_workers))),
     ?assertEqual(5, length(pool_call(Pid, get_all_workers))),
@@ -250,10 +257,10 @@ pool_empty_no_overflow() ->
     ?assertEqual(0, length(pool_call(Pid, get_all_monitors))),
     ok = pool_call(Pid, stop).
 
-worker_death() ->
+worker_death(Type) ->
     %% Check that dead workers are only restarted when the pool is not full
     %% and the overflow count is 0. Meaning, don't restart overflow workers.
-    {ok, Pid} = new_pool(5, 2),
+    {ok, Pid} = new_pool(5, 2, lifo, Type),
     Worker = poolboy:checkout(Pid),
     kill_worker(Worker),
     ?assertEqual(5, length(pool_call(Pid, get_avail_workers))),
@@ -270,11 +277,11 @@ worker_death() ->
     ?assertEqual(4, length(pool_call(Pid, get_all_monitors))),
     ok = pool_call(Pid, stop).
 
-worker_death_while_full() ->
+worker_death_while_full(Type) ->
     %% Check that if a worker dies while the pool is full and there is a
     %% queued checkout, a new worker is started and the checkout serviced.
     %% If there are no queued checkouts, a new worker is not started.
-    {ok, Pid} = new_pool(5, 2),
+    {ok, Pid} = new_pool(5, 2, lifo, Type),
     Worker = poolboy:checkout(Pid),
     kill_worker(Worker),
     ?assertEqual(5, length(pool_call(Pid, get_avail_workers))),
@@ -311,11 +318,11 @@ worker_death_while_full() ->
     ?assertEqual(6, length(pool_call(Pid, get_all_monitors))),
     ok = pool_call(Pid, stop).
 
-worker_death_while_full_no_overflow() ->
+worker_death_while_full_no_overflow(Type) ->
     %% Check that if a worker dies while the pool is full and there's no
     %% overflow, a new worker is started unconditionally and any queued
     %% checkouts are serviced.
-    {ok, Pid} = new_pool(5, 0),
+    {ok, Pid} = new_pool(5, 0, lifo, Type),
     Worker = poolboy:checkout(Pid),
     kill_worker(Worker),
     ?assertEqual(5, length(pool_call(Pid, get_avail_workers))),
@@ -354,10 +361,10 @@ worker_death_while_full_no_overflow() ->
     ?assertEqual(3, length(pool_call(Pid, get_all_monitors))),
     ok = pool_call(Pid, stop).
 
-pool_full_nonblocking_no_overflow() ->
+pool_full_nonblocking_no_overflow(Type) ->
     %% Check that when the pool is full, checkouts return 'full' when the
     %% option to use non-blocking checkouts is used.
-    {ok, Pid} = new_pool(5, 0),
+    {ok, Pid} = new_pool(5, 0, lifo, Type),
     Workers = [poolboy:checkout(Pid) || _ <- lists:seq(0, 4)],
     ?assertEqual(0, length(pool_call(Pid, get_avail_workers))),
     ?assertEqual(5, length(pool_call(Pid, get_all_workers))),
@@ -369,10 +376,10 @@ pool_full_nonblocking_no_overflow() ->
     ?assertEqual(5, length(pool_call(Pid, get_all_monitors))),
     ok = pool_call(Pid, stop).
 
-pool_full_nonblocking() ->
+pool_full_nonblocking(Type) ->
     %% Check that when the pool is full, checkouts return 'full' when the
     %% option to use non-blocking checkouts is used.
-    {ok, Pid} = new_pool(5, 5),
+    {ok, Pid} = new_pool(5, 5, lifo, Type),
     Workers = [poolboy:checkout(Pid) || _ <- lists:seq(0, 9)],
     ?assertEqual(0, length(pool_call(Pid, get_avail_workers))),
     ?assertEqual(10, length(pool_call(Pid, get_all_workers))),
@@ -386,10 +393,10 @@ pool_full_nonblocking() ->
     ?assertEqual(10, length(pool_call(Pid, get_all_monitors))),
     ok = pool_call(Pid, stop).
 
-owner_death() ->
+owner_death(Type) ->
     %% Check that a dead owner (a process that dies with a worker checked out)
     %% causes the pool to dismiss the worker and prune the state space.
-    {ok, Pid} = new_pool(5, 5),
+    {ok, Pid} = new_pool(5, 5, lifo, Type),
     spawn(fun() ->
         poolboy:checkout(Pid),
         receive after 500 -> exit(normal) end
@@ -400,8 +407,8 @@ owner_death() ->
     ?assertEqual(0, length(pool_call(Pid, get_all_monitors))),
     ok = pool_call(Pid, stop).
 
-checkin_after_exception_in_transaction() ->
-    {ok, Pool} = new_pool(2, 0),
+checkin_after_exception_in_transaction(Type) ->
+    {ok, Pool} = new_pool(2, 0, lifo, Type),
     ?assertEqual(2, length(pool_call(Pool, get_avail_workers))),
     Tx = fun(Worker) ->
         ?assert(is_pid(Worker)),
@@ -417,8 +424,8 @@ checkin_after_exception_in_transaction() ->
     ?assertEqual(2, length(pool_call(Pool, get_avail_workers))),
     ok = pool_call(Pool, stop).
 
-pool_returns_status() ->
-    {ok, Pool} = new_pool(2, 0),
+pool_returns_status(Type) ->
+    {ok, Pool} = new_pool(2, 0, lifo, Type),
     ?assertEqual({ready, 2, 0, 0}, poolboy:status(Pool)),
     poolboy:checkout(Pool),
     ?assertEqual({ready, 1, 0, 1}, poolboy:status(Pool)),
@@ -446,8 +453,8 @@ pool_returns_status() ->
     ?assertEqual({full, 0, 0, 0}, poolboy:status(Pool4)),
     ok = pool_call(Pool4, stop).
 
-demonitors_previously_waiting_processes() ->
-    {ok, Pool} = new_pool(1,0),
+demonitors_previously_waiting_processes(Type) ->
+    {ok, Pool} = new_pool(1,0, lifo, Type),
     Self = self(),
     Pid = spawn(fun() ->
         W = poolboy:checkout(Pool),
@@ -465,8 +472,8 @@ demonitors_previously_waiting_processes() ->
     Pid ! ok,
     ok = pool_call(Pool, stop).
 
-demonitors_when_checkout_cancelled() ->
-    {ok, Pool} = new_pool(1,0),
+demonitors_when_checkout_cancelled(Type) ->
+    {ok, Pool} = new_pool(1,0, lifo, Type),
     Self = self(),
     Pid = spawn(fun() ->
         poolboy:checkout(Pool),
@@ -481,23 +488,23 @@ demonitors_when_checkout_cancelled() ->
     Pid ! ok,
     ok = pool_call(Pool, stop).
 
-default_strategy_lifo() ->
+default_strategy_lifo(Type) ->
     %% Default strategy is LIFO
-    {ok, Pid} = new_pool(2, 0),
+    {ok, Pid} = new_pool(2, 0, default, Type),
     Worker1 = poolboy:checkout(Pid),
     ok = poolboy:checkin(Pid, Worker1),
     Worker1 = poolboy:checkout(Pid),
     poolboy:stop(Pid).
 
-lifo_strategy() ->
-    {ok, Pid} = new_pool(2, 0, lifo),
+lifo_strategy(Type) ->
+    {ok, Pid} = new_pool(2, 0, lifo, Type),
     Worker1 = poolboy:checkout(Pid),
     ok = poolboy:checkin(Pid, Worker1),
     Worker1 = poolboy:checkout(Pid),
     poolboy:stop(Pid).
 
-fifo_strategy() ->
-    {ok, Pid} = new_pool(2, 0, fifo),
+fifo_strategy(Type) ->
+    {ok, Pid} = new_pool(2, 0, fifo, Type),
     Worker1 = poolboy:checkout(Pid),
     ok = poolboy:checkin(Pid, Worker1),
     Worker2 = poolboy:checkout(Pid),
@@ -505,8 +512,8 @@ fifo_strategy() ->
     Worker1 = poolboy:checkout(Pid),
     poolboy:stop(Pid).
 
-reuses_waiting_monitor_on_worker_exit() ->
-    {ok, Pool} = new_pool(1,0),
+reuses_waiting_monitor_on_worker_exit(Type) ->
+    {ok, Pool} = new_pool(1,0, lifo, Type),
 
     Self = self(),
     Pid = spawn(fun() ->
@@ -540,11 +547,21 @@ new_pool(Size, MaxOverflow) ->
                         {worker_module, poolboy_test_worker},
                         {size, Size}, {max_overflow, MaxOverflow}]).
 
-new_pool(Size, MaxOverflow, Strategy) ->
+new_pool(Size, MaxOverflow, default, Type) ->
     poolboy:start_link([{name, {local, poolboy_test}},
                         {worker_module, poolboy_test_worker},
-                        {size, Size}, {max_overflow, MaxOverflow},
+                        {size, Size}, {max_overflow, MaxOverflow}, {type, Type}]);
+
+new_pool(Size, MaxOverflow, Strategy, Type) ->
+    poolboy:start_link([{name, {local, poolboy_test}},
+                        {worker_module, poolboy_test_worker},
+                        {size, Size}, {max_overflow, MaxOverflow}, {type, Type},
                         {strategy, Strategy}]).
 
+pool_call(ServerRef, stop) when is_pid(ServerRef) ->
+    case is_process_alive(ServerRef) of
+        true -> gen_server:stop(ServerRef);
+        _ -> ok
+    end;
 pool_call(ServerRef, Request) ->
     gen_server:call(ServerRef, Request).


### PR DESCRIPTION
This PR should really be 2 as the title suggest. However, it was easier for me the to create it as single one. - Apologies! - I just wanted to get your thoughts on the changes first and find out whether you see these extensions useful. - I'm happy to take this further, e.g.: split the PR, etc.

### Remote Workers
I use `poolboy` at work and needed to create a pool of processes similar to the `rpc` module implementation in Erlang/OTP. - `rpc` (or `rex`) is a single process, I needed a pool of them. - This led me to extend `poolboy`, so that (local) workers could be started by a supervisor on a remote node.

### Worker Collection
In situations, where the worker is non-blocking, the pool performs better if the `checkout`, `checkin` mechanism is not used. However, it's still a good idea to distribute the work-load between workers, e.g.: simply relying on random distribution. - This led me to consider `random-access` data-structures, like `array` and `tuple` for the collection of workers. - I've added a module: `poolboy_collection` that encapsulates the data-structure, in which the workers are stored.