### PR TITLE
Fix premature exit

### DIFF
--- a/src/poolboy.erl
+++ b/src/poolboy.erl
@@ -279,10 +279,14 @@ handle_info({'EXIT', Pid, _Reason}, State) ->
 handle_info(_Info, State) ->
     {noreply, State}.
 
-terminate(_Reason, State) ->
+terminate(_Reason, #state{supervisor = Sup} = State) ->
     Workers = queue:to_list(State#state.workers),
     ok = lists:foreach(fun (W) -> unlink(W) end, Workers),
-    true = exit(State#state.supervisor, shutdown),
+    true = exit(Sup, shutdown),
+    receive
+        {'EXIT', Sup, _Reason} ->
+            ok
+    end,
     ok.
 
 code_change(_OldVsn, State, _Extra) ->


### PR DESCRIPTION
I met a lot of the following error logs when I execute `init:stop()`
```
14:46:29.924 [error] Undefined:Undefined gen_server <0.1199.0> terminated with reason: killed
14:46:29.924 [error] Undefined:Undefined CRASH REPORT Process <0.1199.0> with 0 neighbours exited with reason: killed in gen_server:decode_msg/9 line 432
```
And terminate function of mysql_conn.erl didn't get fully executed.

I have a pool size of 1600, maybe this caused this problem to be obvious.

Because `exit(State#state.supervisor, shutdown)` is async shutdown, the pool process passed away immediately,
so State#state.supervisor gets also killed, 
Now that parent of all workers is dead, so workers show messages pasted above(gen_server:decode_msg/9 line 432), 
So we need to wait a little bit to allow workers to terminate properly.