### PR TITLE
Remote Workers and Worker-Supervisor

### DIFF
--- a/src/poolboy.erl
+++ b/src/poolboy.erl
@@ -308,10 +308,12 @@ handle_info({nodedown, Node}, State = #state{supervisor = {_, Node}}) ->
 handle_info(_Info, State) ->
     {noreply, State}.
 
-terminate(_Reason, State) ->
+terminate(_Reason, State = #state{supervisor = Sup}) ->
     Workers = queue:to_list(State#state.workers),
     ok = lists:foreach(fun (W) -> unlink(W) end, Workers),
-    true = exit(State#state.supervisor, shutdown),
+    if is_pid(Sup) -> true = exit(Sup, shutdown);
+       true -> ok = gen_server:stop(Sup)
+    end,
     ok.
 
 code_change(_OldVsn, State, _Extra) ->

--- a/src/poolboy.erl
+++ b/src/poolboy.erl
@@ -354,7 +354,11 @@ start_pool(StartFun, PoolArgs, WorkerArgs) ->
     end.
 
 new_worker(Sup) ->
-    {ok, Pid} = supervisor:start_child(Sup, []),
+    {ok, Pid} =
+    case is_atom(Sup) andalso erlang:function_exported(Sup, start_child, 0) of
+        true -> Sup:start_child();
+        false -> supervisor:start_child(Sup, [])
+    end,
     true = link(Pid),
     Pid.
 

--- a/src/poolboy.erl
+++ b/src/poolboy.erl
@@ -438,6 +438,8 @@ state_name(_State) ->
     overflow.
 
 stop_supervisor(_, undefined) -> ok;
+stop_supervisor(Reason, Atom) when is_atom(Atom) ->
+    stop_supervisor(Reason, whereis(Atom));
 stop_supervisor(Reason, Pid) when is_pid(Pid) ->
     case erlang:node(Pid) of
         N when N == node() -> exit(Pid, Reason);

--- a/src/poolboy.erl
+++ b/src/poolboy.erl
@@ -159,7 +159,7 @@ init({PoolArgs, WorkerArgs}) ->
         undefined ->
             start_supervisor(WorkerModule, WorkerArgs);
         Sup when is_pid(Sup) ->
-            true = link(Sup),
+            monitor(process, Sup),
             Sup
     end,
     Size = pool_size(PoolArgs),
@@ -323,6 +323,8 @@ handle_call(_Msg, _From, State) ->
     Reply = {error, invalid_message},
     {reply, Reply, State}.
 
+handle_info({'DOWN', _, process, Pid, Reason}, State = #state{supervisor = Pid}) ->
+    {stop, Reason, State};
 handle_info({'DOWN', MRef, _, _, _}, State) ->
     case ets:match(State#state.monitors, {'$1', '_', MRef}) of
         [[Pid]] ->

--- a/src/poolboy.erl
+++ b/src/poolboy.erl
@@ -231,13 +231,15 @@ find_pid({via, Registry, Name}) ->
     Registry:whereis_name(Name);
 find_pid({Name, Node}) ->
     (catch erlang:monitor_node(Node, true)),
-    try rpc:call(Node, erlang, whereis, [Name], ?TIMEOUT) of
-        {badrpc, Reason} -> Reason;
-        Result -> Result
-    catch
-        _:Reason -> Reason
+    try rpc_call(Node, erlang, whereis, [Name], ?TIMEOUT)
+    catch _:Reason -> Reason
     end.
 
+rpc_call(Node, Mod, Fun, Args, Timeout) ->
+    case rpc:call(Node, Mod, Fun, Args, Timeout) of
+        {badrpc, Reason} -> exit({Reason, {Node, {Mod, Fun, Args}}});
+        Result -> Result
+    end.
 
 pool_size(PoolArgs) ->
     Is = is_integer(V = proplists:get_value(size, PoolArgs)),
@@ -392,10 +394,10 @@ start_pool(StartFun, PoolArgs, WorkerArgs) ->
 new_worker(Sup, Mod)  ->
     Node = erlang:node(Sup),
     {ok, Pid} =
-    case rpc:pinfo(Sup, registered_name) of
+    case rpc_call(Node, erlang, process_info, [Sup, registered_name], ?TIMEOUT) of
         {registered_name, Name} ->
             case function_exported(Node, Name, start_child, 0) of
-                true -> rpc:call(Node, Name, start_child, []);
+                true -> rpc_call(Node, Name, start_child, [], ?TIMEOUT);
                 false ->
                     Args = child_args(Sup, Mod),
                     supervisor:start_child(Sup, Args)
@@ -427,7 +429,7 @@ child_args(Sup, Mod) ->
     end.
 
 function_exported(Node, Module, Name, Arity) ->
-    rpc:call(Node, erlang, function_exported, [Module, Name, Arity]).
+    rpc_call(Node, erlang, function_exported, [Module, Name, Arity], ?TIMEOUT).
 
 dismiss_worker(Sup, Pid) ->
     true = unlink(Pid),

--- a/src/poolboy_sup.erl
+++ b/src/poolboy_sup.erl
@@ -6,7 +6,7 @@
 -export([start_link/2, init/1]).
 
 start_link(Mod, Args) ->
-    supervisor:start_link(?MODULE, {Mod, Args}).
+    supervisor:start_link({local, ?MODULE}, ?MODULE, {Mod, Args}).
 
 init({Mod, Args}) ->
     {ok, {{simple_one_for_one, 0, 1},

--- a/src/poolboy_sup.erl
+++ b/src/poolboy_sup.erl
@@ -6,7 +6,7 @@
 -export([start_link/2, init/1]).
 
 start_link(Mod, Args) ->
-    supervisor:start_link({local, ?MODULE}, ?MODULE, {Mod, Args}).
+    supervisor:start_link({local, Mod}, ?MODULE, {Mod, Args}).
 
 init({Mod, Args}) ->
     {ok, {{simple_one_for_one, 0, 1},

--- a/src/poolboy_worker_supervisor.erl
+++ b/src/poolboy_worker_supervisor.erl
@@ -1,0 +1,6 @@
+-module(poolboy_worker_supervisor).
+
+-callback start_child() -> {ok, Pid} |
+                           {error, Reason} when
+    Pid    :: pid(),
+    Reason :: term().


### PR DESCRIPTION
# Remote Workers

I needed to create a pool of processes similar to the `rpc` module implementation in Erlang/OTP. - `rpc` (or `rex`) is a single process, I needed a pool of them. - This led me to extend poolboy, so that (local) workers could be started by a supervisor on a remote node.

For this to work  these are the necessary steps:
1. Find the `Pid` of the Worker-Supervisor, even if remote, see `find_pid/1`
2. Start the workers via their Supervisor, even if Supervisor is remote, see `new_worker/2`
3. Monitor Worker-Supervisors, that were passed in and `stop` if they go `DOWN`
4. Monitor Remote `node` if Worker-Supervisor is remote and `stop` on `nodedown`
4. Stop Worker-Supervisor using `gen_server:stop/1`, so that it works remotely too. See: `stop_supervisor/2`